### PR TITLE
feat(redis): add redis monitoring plugin

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/BurntSushi/toml"
 	"github.com/cprobe/catpaw/config"
 	"github.com/cprobe/catpaw/logger"
 	"github.com/cprobe/catpaw/pkg/choice"
 	"github.com/cprobe/catpaw/plugins"
-	"github.com/BurntSushi/toml"
 	"github.com/toolkits/pkg/file"
 
 	// auto registry
@@ -28,12 +28,13 @@ import (
 	_ "github.com/cprobe/catpaw/plugins/mem"
 	_ "github.com/cprobe/catpaw/plugins/mount"
 	_ "github.com/cprobe/catpaw/plugins/neigh"
-	_ "github.com/cprobe/catpaw/plugins/netif"
 	_ "github.com/cprobe/catpaw/plugins/net"
+	_ "github.com/cprobe/catpaw/plugins/netif"
 	_ "github.com/cprobe/catpaw/plugins/ntp"
 	_ "github.com/cprobe/catpaw/plugins/ping"
 	_ "github.com/cprobe/catpaw/plugins/procfd"
 	_ "github.com/cprobe/catpaw/plugins/procnum"
+	_ "github.com/cprobe/catpaw/plugins/redis"
 	_ "github.com/cprobe/catpaw/plugins/scriptfilter"
 	_ "github.com/cprobe/catpaw/plugins/secmod"
 	_ "github.com/cprobe/catpaw/plugins/sockstat"

--- a/conf.d/p.redis/redis.toml
+++ b/conf.d/p.redis/redis.toml
@@ -1,0 +1,160 @@
+[[partials]]
+## ===== 最小可用示例（30 秒跑起来）=====
+## 1) 在 instances.targets 里填 Redis 地址，支持 host 或 host:port
+## 2) 如果 Redis 需要认证，填 password 或 username + password
+## 3) 默认只做 connectivity；其他维度按需开启
+## 例子：
+## targets = ["127.0.0.1", "10.0.0.8:6379"]
+## password = "pa$$word"
+## [instances.role]
+## expect = "master"
+## [instances.used_memory]
+## warn_ge = "512MB"
+
+id = "default"
+
+## 每个 instance 并发探测数
+# concurrency = 10
+
+## 建连和写超时（默认 3s）
+# timeout = "3s"
+
+## 读超时（默认 2s）
+# read_timeout = "2s"
+
+## Redis ACL 用户名（Redis 6+）
+# username = "default"
+
+## Redis 密码
+# password = "pa$$word"
+
+## 选择数据库（默认 0）
+# db = 0
+
+## TLS 可选配置（原生 TLS / stunnel / 云 Redis）
+# use_tls = false
+# tls_ca = "/etc/catpaw/ca.pem"
+# tls_cert = "/etc/catpaw/cert.pem"
+# tls_key = "/etc/catpaw/key.pem"
+# tls_server_name = "redis.example.com"
+# insecure_skip_verify = false
+
+## 连通性检测（默认启用，默认 Critical）
+## check 标签固定为 "redis::connectivity"
+[partials.connectivity]
+severity = "Critical"
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 响应时间检测（warn_ge 和 critical_ge 都为 0 则关闭）
+## check 标签固定为 "redis::response_time"
+# [partials.response_time]
+# warn_ge = "20ms"
+# critical_ge = "100ms"
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 角色检测（expect 为空则关闭）
+## 可选值：master / slave / replica
+## check 标签固定为 "redis::role"
+# [partials.role]
+# expect = "master"
+# severity = "Warning"
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 客户端连接数检测（两个阈值都为 0 则关闭）
+## check 标签固定为 "redis::connected_clients"
+# [partials.connected_clients]
+# warn_ge = 500
+# critical_ge = 1000
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 阻塞客户端数检测（两个阈值都为 0 则关闭）
+## check 标签固定为 "redis::blocked_clients"
+# [partials.blocked_clients]
+# warn_ge = 1
+# critical_ge = 5
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 内存使用量检测（两个阈值都为 0 则关闭）
+## 支持 B / KB / MB / GB / TB
+## check 标签固定为 "redis::used_memory"
+# [partials.used_memory]
+# warn_ge = "512MB"
+# critical_ge = "1GB"
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 被拒绝连接数检测（两个阈值都为 0 则关闭）
+## 指标来自 INFO stats 的 rejected_connections
+## check 标签固定为 "redis::rejected_connections"
+# [partials.rejected_connections]
+# warn_ge = 1
+# critical_ge = 10
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 已连接副本数下限检测（两个阈值都为 0 则关闭）
+## 适用于 master，指标来自 INFO replication 的 connected_slaves
+## check 标签固定为 "redis::connected_slaves"
+# [partials.connected_slaves]
+# warn_lt = 2
+# critical_lt = 1
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 每周期淘汰键数量检测（两个阈值都为 0 则关闭）
+## 注意：这是采集周期内 delta，不是 Redis 启动以来累计值
+## check 标签固定为 "redis::evicted_keys"
+# [partials.evicted_keys]
+# warn_ge = 1
+# critical_ge = 10
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 每周期过期键数量检测（两个阈值都为 0 则关闭）
+## 注意：这是采集周期内 delta，不是 Redis 启动以来累计值
+## check 标签固定为 "redis::expired_keys"
+# [partials.expired_keys]
+# warn_ge = 100
+# critical_ge = 1000
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 瞬时 QPS 检测（两个阈值都为 0 则关闭）
+## 指标来自 INFO stats 的 instantaneous_ops_per_sec
+## check 标签固定为 "redis::instantaneous_ops_per_sec"
+# [partials.instantaneous_ops_per_sec]
+# warn_ge = 5000
+# critical_ge = 20000
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 主从链路状态检测（expect 为空则关闭）
+## 适用于 replica 节点，期望值通常为 up
+## check 标签固定为 "redis::master_link_status"
+# [partials.master_link_status]
+# expect = "up"
+# severity = "Warning"
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+## 持久化状态检测（enabled = true 时启用）
+## 检查 loading / rdb_last_bgsave_status / aof_last_write_status
+## check 标签固定为 "redis::persistence"
+# [partials.persistence]
+# enabled = true
+# severity = "Critical"
+# title_rule = "[TPL]${check} ${from_hostip} ${target}"
+
+
+[[instances]]
+targets = [
+#    "127.0.0.1",
+]
+
+partial = "default"
+
+## 采集间隔
+# interval = "30s"
+
+## 追加标签（可选）
+# labels = { env="production", team="middleware" }
+
+[instances.alerting]
+for_duration = 0
+repeat_interval = "5m"
+repeat_number = 3
+# disabled = false
+# disable_recovery_notification = false

--- a/plugins/redis/design.md
+++ b/plugins/redis/design.md
@@ -1,0 +1,162 @@
+# redis 插件设计
+
+## 概述
+
+监控 Redis 服务的可用性、响应时间、主从复制状态、客户端负载、吞吐和持久化健康。
+
+**核心场景**：
+
+1. **Redis 不可达**：进程挂了、端口不通、TLS/认证配置错误
+2. **Redis 变慢**：实例负载升高或网络抖动导致 PING 响应时间增加
+3. **主从角色漂移**：预期 master 的节点变成 replica，或反之
+4. **客户端积压**：连接数过高或 blocked clients 增长，通常意味着应用或 Lua/事务阻塞
+5. **内存压力**：`used_memory` 接近容量上限，可能触发淘汰或 OOM
+6. **拒绝连接**：`rejected_connections` 增长，通常意味着 `maxclients` 或资源耗尽
+7. **复制链路异常**：replica 的 `master_link_status` 不为 `up`
+8. **持久化异常**：RDB 最近一次 bgsave 失败或 AOF 最近一次写入失败
+9. **副本数量异常**：master 的 `connected_slaves` 数量低于预期
+10. **淘汰和过期激增**：单个采集周期内 `evicted_keys` / `expired_keys` 突增
+11. **瞬时吞吐升高**：`instantaneous_ops_per_sec` 超过阈值
+
+**与现有插件的关系**：`net` 只能做通用 TCP send/expect，无法理解 Redis 的 AUTH、SELECT、INFO 和角色/客户端指标。`redis` 插件在保持轻量实现的前提下补上了 Redis 语义层检查。
+
+## 检查维度
+
+| 维度 | check label | target | 说明 |
+| --- | --- | --- | --- |
+| 连通性 | `redis::connectivity` | host:port | 建连、可选 AUTH/SELECT 后执行 `PING` |
+| 响应时间 | `redis::response_time` | host:port | 从建连到收到 `PONG` 的总耗时 |
+| 角色 | `redis::role` | host:port | `INFO replication` 的 `role` 是否符合预期 |
+| 客户端连接数 | `redis::connected_clients` | host:port | `INFO clients` 的连接数是否超阈值 |
+| 阻塞客户端数 | `redis::blocked_clients` | host:port | `INFO clients` 的阻塞客户端数是否超阈值 |
+| 内存使用量 | `redis::used_memory` | host:port | `INFO memory` 的 `used_memory` 是否超阈值 |
+| 拒绝连接数 | `redis::rejected_connections` | host:port | `INFO stats` 的 `rejected_connections` 是否超阈值 |
+| 主从链路状态 | `redis::master_link_status` | host:port | replica 的 `master_link_status` 是否符合预期 |
+| 已连接副本数 | `redis::connected_slaves` | host:port | master 的 `connected_slaves` 是否低于最小副本数 |
+| 淘汰键数量 | `redis::evicted_keys` | host:port | `INFO stats` 的 `evicted_keys` 周期增量是否超阈值 |
+| 过期键数量 | `redis::expired_keys` | host:port | `INFO stats` 的 `expired_keys` 周期增量是否超阈值 |
+| 瞬时吞吐 | `redis::instantaneous_ops_per_sec` | host:port | `INFO stats` 的瞬时 ops 是否超阈值 |
+| 持久化状态 | `redis::persistence` | host:port | `loading`、`rdb_last_bgsave_status`、`aof_last_write_status` 是否健康 |
+
+- 每个 target 独立事件
+- 支持并发检查（默认 10）
+- 支持 `partials` 复用认证、TLS、超时和阈值配置
+
+## 配置设计
+
+```go
+type Instance struct {
+    config.InternalConfig
+    Targets      []string
+    Concurrency  int
+    Timeout      config.Duration
+    ReadTimeout  config.Duration
+    Username     string
+    Password     string
+    DB           int
+    tls.ClientConfig
+
+    Connectivity    ConnectivityCheck
+    ResponseTime    ResponseTimeCheck
+    Role            RoleCheck
+    ConnectedClients CountCheck
+    BlockedClients   CountCheck
+    UsedMemory       MemoryUsageCheck
+    RejectedConn     CountCheck
+    MasterLink       MasterLinkCheck
+    ConnectedSlaves  MinCountCheck
+    EvictedKeys      CountCheck
+    ExpiredKeys      CountCheck
+    OpsPerSecond     OpsPerSecondCheck
+    Persistence      PersistenceCheck
+}
+```
+
+### 认证与数据库
+
+- `password` 非空时执行 `AUTH`
+- `username + password` 同时配置时走 Redis ACL 模式 `AUTH user pass`
+- `db > 0` 时执行 `SELECT <db>`
+
+### TLS
+
+复用项目现有 `tls.ClientConfig`：
+
+- `use_tls`
+- `tls_ca`
+- `tls_cert`
+- `tls_key`
+- `tls_server_name`
+- `insecure_skip_verify`
+
+适用于 Redis 原生 TLS、stunnel、云 Redis 代理等场景。
+
+## Init() 校验
+
+1. `targets` 允许 `host` 或 `host:port`
+2. 未显式指定端口时自动补 `:6379`
+3. `response_time.warn_ge < critical_ge`
+4. `role.expect` 只允许 `master`、`slave`、`replica`（内部统一成 `slave`）
+5. `connected_clients` / `blocked_clients` 阈值必须非负，且 `warn < critical`
+6. `db >= 0`
+
+## Gather() 逻辑
+
+对每个 target：
+
+1. 建立 TCP/TLS 连接
+2. 如有需要执行 `AUTH`
+3. 如有需要执行 `SELECT`
+4. 执行 `PING`
+5. 产出 `connectivity` 和 `response_time`
+6. 如启用 `role` / `master_link_status`，执行 `INFO replication`
+7. 如启用 `connected_clients` / `blocked_clients`，执行 `INFO clients`
+8. 如启用 `used_memory`，执行 `INFO memory`
+9. 如启用 `rejected_connections` / `evicted_keys` / `expired_keys` / `instantaneous_ops_per_sec`，执行 `INFO stats`
+10. 如启用 `connected_slaves`，复用 `INFO replication`
+11. 如启用 `persistence`，执行 `INFO persistence`
+
+### 失败处理
+
+- 任一步骤失败，`connectivity` 直接告警
+- `INFO` 查询失败时，对对应维度产出 Critical，避免静默漏报
+
+### 持久化检查规则
+
+- `loading = 1` 直接告警
+- `rdb_last_bgsave_status != ok` 告警
+- `aof_enabled = 1` 且 `aof_last_write_status != ok` 告警
+- 其他情况为 Ok
+
+### 增量计数器检查规则
+
+- `evicted_keys` 和 `expired_keys` 使用两个采集周期之间的 delta，不直接使用 Redis 启动以来累计值
+- 首次采集只建立 baseline，产出 Ok 事件，delta=0
+- 如果计数器回绕或 Redis 重启导致值变小，本周期按 delta=0 处理
+
+### connected_slaves 检查规则
+
+- 使用 `warn_lt` / `critical_lt`
+- 适用于 master 节点
+- 示例：`warn_lt = 2`, `critical_lt = 1` 表示副本数少于 2 预警，少于 1 严重告警
+
+## 默认策略
+
+- `connectivity.severity = "Critical"`
+- `role.severity = "Warning"`，因为角色漂移是否致命依赖拓扑；用户可提升为 Critical
+- `master_link_status.severity = "Warning"`，复制拓扑问题通常先预警
+- `persistence.severity = "Critical"`，RDB/AOF 失败通常意味着数据安全风险
+- `connected_slaves` 没有单独 severity，按阈值走 Warning/Critical
+- `evicted_keys` / `expired_keys` 因为是 delta 阈值，建议结合业务流量设置，不建议照抄固定值
+- 其他阈值默认关闭，由用户按容量和业务模型设置
+
+## 参考
+
+- Redis `PING`
+- Redis `AUTH`
+- Redis `SELECT`
+- Redis `INFO replication`
+- Redis `INFO clients`
+- Redis `INFO memory`
+- Redis `INFO stats`
+- Redis `INFO persistence`

--- a/plugins/redis/redis.go
+++ b/plugins/redis/redis.go
@@ -1,0 +1,1394 @@
+package redis
+
+import (
+	"bufio"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cprobe/catpaw/config"
+	"github.com/cprobe/catpaw/logger"
+	"github.com/cprobe/catpaw/pkg/conv"
+	"github.com/cprobe/catpaw/pkg/safe"
+	tlscfg "github.com/cprobe/catpaw/pkg/tls"
+	"github.com/cprobe/catpaw/plugins"
+	"github.com/cprobe/catpaw/types"
+	"github.com/toolkits/pkg/concurrent/semaphore"
+)
+
+const (
+	pluginName       = "redis"
+	defaultRedisPort = "6379"
+)
+
+type ConnectivityCheck struct {
+	Severity  string `toml:"severity"`
+	TitleRule string `toml:"title_rule"`
+}
+
+type ResponseTimeCheck struct {
+	WarnGe     config.Duration `toml:"warn_ge"`
+	CriticalGe config.Duration `toml:"critical_ge"`
+	TitleRule  string          `toml:"title_rule"`
+}
+
+type RoleCheck struct {
+	Expect    string `toml:"expect"`
+	Severity  string `toml:"severity"`
+	TitleRule string `toml:"title_rule"`
+}
+
+type CountCheck struct {
+	WarnGe     int    `toml:"warn_ge"`
+	CriticalGe int    `toml:"critical_ge"`
+	TitleRule  string `toml:"title_rule"`
+}
+
+type MinCountCheck struct {
+	WarnLt     int    `toml:"warn_lt"`
+	CriticalLt int    `toml:"critical_lt"`
+	TitleRule  string `toml:"title_rule"`
+}
+
+type MemoryUsageCheck struct {
+	WarnGe     config.Size `toml:"warn_ge"`
+	CriticalGe config.Size `toml:"critical_ge"`
+	TitleRule  string      `toml:"title_rule"`
+}
+
+type MasterLinkCheck struct {
+	Expect    string `toml:"expect"`
+	Severity  string `toml:"severity"`
+	TitleRule string `toml:"title_rule"`
+}
+
+type PersistenceCheck struct {
+	Enabled   bool   `toml:"enabled"`
+	Severity  string `toml:"severity"`
+	TitleRule string `toml:"title_rule"`
+}
+
+type OpsPerSecondCheck struct {
+	WarnGe     int    `toml:"warn_ge"`
+	CriticalGe int    `toml:"critical_ge"`
+	TitleRule  string `toml:"title_rule"`
+}
+
+type Partial struct {
+	ID          string          `toml:"id"`
+	Concurrency int             `toml:"concurrency"`
+	Timeout     config.Duration `toml:"timeout"`
+	ReadTimeout config.Duration `toml:"read_timeout"`
+	Username    string          `toml:"username"`
+	Password    string          `toml:"password"`
+	DB          int             `toml:"db"`
+	tlscfg.ClientConfig
+	Connectivity     ConnectivityCheck `toml:"connectivity"`
+	ResponseTime     ResponseTimeCheck `toml:"response_time"`
+	Role             RoleCheck         `toml:"role"`
+	ConnectedClients CountCheck        `toml:"connected_clients"`
+	BlockedClients   CountCheck        `toml:"blocked_clients"`
+	UsedMemory       MemoryUsageCheck  `toml:"used_memory"`
+	RejectedConn     CountCheck        `toml:"rejected_connections"`
+	MasterLink       MasterLinkCheck   `toml:"master_link_status"`
+	ConnectedSlaves  MinCountCheck     `toml:"connected_slaves"`
+	EvictedKeys      CountCheck        `toml:"evicted_keys"`
+	ExpiredKeys      CountCheck        `toml:"expired_keys"`
+	OpsPerSecond     OpsPerSecondCheck `toml:"instantaneous_ops_per_sec"`
+	Persistence      PersistenceCheck  `toml:"persistence"`
+}
+
+type Instance struct {
+	config.InternalConfig
+	Partial string `toml:"partial"`
+
+	Targets          []string          `toml:"targets"`
+	Concurrency      int               `toml:"concurrency"`
+	Timeout          config.Duration   `toml:"timeout"`
+	ReadTimeout      config.Duration   `toml:"read_timeout"`
+	Username         string            `toml:"username"`
+	Password         string            `toml:"password"`
+	DB               int               `toml:"db"`
+	Connectivity     ConnectivityCheck `toml:"connectivity"`
+	ResponseTime     ResponseTimeCheck `toml:"response_time"`
+	Role             RoleCheck         `toml:"role"`
+	ConnectedClients CountCheck        `toml:"connected_clients"`
+	BlockedClients   CountCheck        `toml:"blocked_clients"`
+	UsedMemory       MemoryUsageCheck  `toml:"used_memory"`
+	RejectedConn     CountCheck        `toml:"rejected_connections"`
+	MasterLink       MasterLinkCheck   `toml:"master_link_status"`
+	ConnectedSlaves  MinCountCheck     `toml:"connected_slaves"`
+	EvictedKeys      CountCheck        `toml:"evicted_keys"`
+	ExpiredKeys      CountCheck        `toml:"expired_keys"`
+	OpsPerSecond     OpsPerSecondCheck `toml:"instantaneous_ops_per_sec"`
+	Persistence      PersistenceCheck  `toml:"persistence"`
+
+	tlscfg.ClientConfig
+	tlsConfig *tls.Config
+	dialFunc  func(network, address string) (net.Conn, error)
+
+	statsMu     sync.Mutex
+	prevStats   map[string]redisCounterSnapshot
+	initialized map[string]bool
+}
+
+type redisCounterSnapshot struct {
+	evictedKeys uint64
+	expiredKeys uint64
+}
+
+type RedisPlugin struct {
+	config.InternalConfig
+	Partials  []Partial   `toml:"partials"`
+	Instances []*Instance `toml:"instances"`
+}
+
+func init() {
+	plugins.Add(pluginName, func() plugins.Plugin {
+		return &RedisPlugin{}
+	})
+}
+
+func (p *RedisPlugin) ApplyPartials() error {
+	for i := 0; i < len(p.Instances); i++ {
+		id := p.Instances[i].Partial
+		if id == "" {
+			continue
+		}
+		for _, partial := range p.Partials {
+			if partial.ID != id {
+				continue
+			}
+			ins := p.Instances[i]
+			if ins.Concurrency == 0 {
+				ins.Concurrency = partial.Concurrency
+			}
+			if ins.Timeout == 0 {
+				ins.Timeout = partial.Timeout
+			}
+			if ins.ReadTimeout == 0 {
+				ins.ReadTimeout = partial.ReadTimeout
+			}
+			if ins.Username == "" {
+				ins.Username = partial.Username
+			}
+			if ins.Password == "" {
+				ins.Password = partial.Password
+			}
+			if ins.DB == 0 {
+				ins.DB = partial.DB
+			}
+			mergeClientConfig(&ins.ClientConfig, partial.ClientConfig)
+			if ins.Connectivity.Severity == "" {
+				ins.Connectivity.Severity = partial.Connectivity.Severity
+			}
+			if ins.Connectivity.TitleRule == "" {
+				ins.Connectivity.TitleRule = partial.Connectivity.TitleRule
+			}
+			if ins.ResponseTime.WarnGe == 0 {
+				ins.ResponseTime.WarnGe = partial.ResponseTime.WarnGe
+			}
+			if ins.ResponseTime.CriticalGe == 0 {
+				ins.ResponseTime.CriticalGe = partial.ResponseTime.CriticalGe
+			}
+			if ins.ResponseTime.TitleRule == "" {
+				ins.ResponseTime.TitleRule = partial.ResponseTime.TitleRule
+			}
+			if ins.Role.Expect == "" {
+				ins.Role.Expect = partial.Role.Expect
+			}
+			if ins.Role.Severity == "" {
+				ins.Role.Severity = partial.Role.Severity
+			}
+			if ins.Role.TitleRule == "" {
+				ins.Role.TitleRule = partial.Role.TitleRule
+			}
+			if ins.ConnectedClients.WarnGe == 0 {
+				ins.ConnectedClients.WarnGe = partial.ConnectedClients.WarnGe
+			}
+			if ins.ConnectedClients.CriticalGe == 0 {
+				ins.ConnectedClients.CriticalGe = partial.ConnectedClients.CriticalGe
+			}
+			if ins.ConnectedClients.TitleRule == "" {
+				ins.ConnectedClients.TitleRule = partial.ConnectedClients.TitleRule
+			}
+			if ins.BlockedClients.WarnGe == 0 {
+				ins.BlockedClients.WarnGe = partial.BlockedClients.WarnGe
+			}
+			if ins.BlockedClients.CriticalGe == 0 {
+				ins.BlockedClients.CriticalGe = partial.BlockedClients.CriticalGe
+			}
+			if ins.BlockedClients.TitleRule == "" {
+				ins.BlockedClients.TitleRule = partial.BlockedClients.TitleRule
+			}
+			if ins.UsedMemory.WarnGe == 0 {
+				ins.UsedMemory.WarnGe = partial.UsedMemory.WarnGe
+			}
+			if ins.UsedMemory.CriticalGe == 0 {
+				ins.UsedMemory.CriticalGe = partial.UsedMemory.CriticalGe
+			}
+			if ins.UsedMemory.TitleRule == "" {
+				ins.UsedMemory.TitleRule = partial.UsedMemory.TitleRule
+			}
+			if ins.MasterLink.Expect == "" {
+				ins.MasterLink.Expect = partial.MasterLink.Expect
+			}
+			if ins.MasterLink.Severity == "" {
+				ins.MasterLink.Severity = partial.MasterLink.Severity
+			}
+			if ins.MasterLink.TitleRule == "" {
+				ins.MasterLink.TitleRule = partial.MasterLink.TitleRule
+			}
+			if ins.RejectedConn.WarnGe == 0 {
+				ins.RejectedConn.WarnGe = partial.RejectedConn.WarnGe
+			}
+			if ins.RejectedConn.CriticalGe == 0 {
+				ins.RejectedConn.CriticalGe = partial.RejectedConn.CriticalGe
+			}
+			if ins.RejectedConn.TitleRule == "" {
+				ins.RejectedConn.TitleRule = partial.RejectedConn.TitleRule
+			}
+			if ins.ConnectedSlaves.WarnLt == 0 {
+				ins.ConnectedSlaves.WarnLt = partial.ConnectedSlaves.WarnLt
+			}
+			if ins.ConnectedSlaves.CriticalLt == 0 {
+				ins.ConnectedSlaves.CriticalLt = partial.ConnectedSlaves.CriticalLt
+			}
+			if ins.ConnectedSlaves.TitleRule == "" {
+				ins.ConnectedSlaves.TitleRule = partial.ConnectedSlaves.TitleRule
+			}
+			if ins.EvictedKeys.WarnGe == 0 {
+				ins.EvictedKeys.WarnGe = partial.EvictedKeys.WarnGe
+			}
+			if ins.EvictedKeys.CriticalGe == 0 {
+				ins.EvictedKeys.CriticalGe = partial.EvictedKeys.CriticalGe
+			}
+			if ins.EvictedKeys.TitleRule == "" {
+				ins.EvictedKeys.TitleRule = partial.EvictedKeys.TitleRule
+			}
+			if ins.ExpiredKeys.WarnGe == 0 {
+				ins.ExpiredKeys.WarnGe = partial.ExpiredKeys.WarnGe
+			}
+			if ins.ExpiredKeys.CriticalGe == 0 {
+				ins.ExpiredKeys.CriticalGe = partial.ExpiredKeys.CriticalGe
+			}
+			if ins.ExpiredKeys.TitleRule == "" {
+				ins.ExpiredKeys.TitleRule = partial.ExpiredKeys.TitleRule
+			}
+			if ins.OpsPerSecond.WarnGe == 0 {
+				ins.OpsPerSecond.WarnGe = partial.OpsPerSecond.WarnGe
+			}
+			if ins.OpsPerSecond.CriticalGe == 0 {
+				ins.OpsPerSecond.CriticalGe = partial.OpsPerSecond.CriticalGe
+			}
+			if ins.OpsPerSecond.TitleRule == "" {
+				ins.OpsPerSecond.TitleRule = partial.OpsPerSecond.TitleRule
+			}
+			if !ins.Persistence.Enabled {
+				ins.Persistence.Enabled = partial.Persistence.Enabled
+			}
+			if ins.Persistence.Severity == "" {
+				ins.Persistence.Severity = partial.Persistence.Severity
+			}
+			if ins.Persistence.TitleRule == "" {
+				ins.Persistence.TitleRule = partial.Persistence.TitleRule
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func (p *RedisPlugin) GetInstances() []plugins.Instance {
+	ret := make([]plugins.Instance, len(p.Instances))
+	for i := 0; i < len(p.Instances); i++ {
+		ret[i] = p.Instances[i]
+	}
+	return ret
+}
+
+func (ins *Instance) Init() error {
+	if ins.Concurrency == 0 {
+		ins.Concurrency = 10
+	}
+	if ins.Timeout == 0 {
+		ins.Timeout = config.Duration(3 * time.Second)
+	}
+	if ins.ReadTimeout == 0 {
+		ins.ReadTimeout = config.Duration(2 * time.Second)
+	}
+	if ins.Connectivity.Severity == "" {
+		ins.Connectivity.Severity = types.EventStatusCritical
+	} else if !types.EventStatusValid(ins.Connectivity.Severity) {
+		return fmt.Errorf("invalid connectivity.severity %q", ins.Connectivity.Severity)
+	}
+	if ins.ResponseTime.WarnGe > 0 && ins.ResponseTime.CriticalGe > 0 && ins.ResponseTime.WarnGe >= ins.ResponseTime.CriticalGe {
+		return fmt.Errorf("response_time.warn_ge(%s) must be less than response_time.critical_ge(%s)",
+			time.Duration(ins.ResponseTime.WarnGe), time.Duration(ins.ResponseTime.CriticalGe))
+	}
+
+	roleExpect, err := normalizeRole(ins.Role.Expect)
+	if err != nil {
+		return err
+	}
+	ins.Role.Expect = roleExpect
+	if ins.Role.Expect != "" {
+		if ins.Role.Severity == "" {
+			ins.Role.Severity = types.EventStatusWarning
+		} else if !types.EventStatusValid(ins.Role.Severity) {
+			return fmt.Errorf("invalid role.severity %q", ins.Role.Severity)
+		}
+	}
+
+	if err := validateCountCheck("connected_clients", ins.ConnectedClients); err != nil {
+		return err
+	}
+	if err := validateCountCheck("blocked_clients", ins.BlockedClients); err != nil {
+		return err
+	}
+	if err := validateCountCheck("rejected_connections", ins.RejectedConn); err != nil {
+		return err
+	}
+	if err := validateMinCountCheck("connected_slaves", ins.ConnectedSlaves); err != nil {
+		return err
+	}
+	if err := validateCountCheck("evicted_keys", ins.EvictedKeys); err != nil {
+		return err
+	}
+	if err := validateCountCheck("expired_keys", ins.ExpiredKeys); err != nil {
+		return err
+	}
+	if err := validateCountCheck("instantaneous_ops_per_sec", CountCheck{
+		WarnGe:     ins.OpsPerSecond.WarnGe,
+		CriticalGe: ins.OpsPerSecond.CriticalGe,
+		TitleRule:  ins.OpsPerSecond.TitleRule,
+	}); err != nil {
+		return err
+	}
+	if ins.UsedMemory.WarnGe < 0 || ins.UsedMemory.CriticalGe < 0 {
+		return fmt.Errorf("used_memory thresholds must be >= 0")
+	}
+	if ins.UsedMemory.WarnGe > 0 && ins.UsedMemory.CriticalGe > 0 && ins.UsedMemory.WarnGe >= ins.UsedMemory.CriticalGe {
+		return fmt.Errorf("used_memory.warn_ge(%s) must be less than used_memory.critical_ge(%s)",
+			ins.UsedMemory.WarnGe.String(), ins.UsedMemory.CriticalGe.String())
+	}
+	masterLinkExpect, err := normalizeMasterLinkStatus(ins.MasterLink.Expect)
+	if err != nil {
+		return err
+	}
+	ins.MasterLink.Expect = masterLinkExpect
+	if ins.MasterLink.Expect != "" {
+		if ins.MasterLink.Severity == "" {
+			ins.MasterLink.Severity = types.EventStatusWarning
+		} else if !types.EventStatusValid(ins.MasterLink.Severity) {
+			return fmt.Errorf("invalid master_link_status.severity %q", ins.MasterLink.Severity)
+		}
+	}
+	if ins.Persistence.Enabled {
+		if ins.Persistence.Severity == "" {
+			ins.Persistence.Severity = types.EventStatusCritical
+		} else if !types.EventStatusValid(ins.Persistence.Severity) {
+			return fmt.Errorf("invalid persistence.severity %q", ins.Persistence.Severity)
+		}
+	}
+	if ins.Username != "" && ins.Password == "" {
+		return fmt.Errorf("password must not be empty when username is set")
+	}
+	if ins.DB < 0 {
+		return fmt.Errorf("db must be >= 0 (got %d)", ins.DB)
+	}
+
+	for i := 0; i < len(ins.Targets); i++ {
+		target, err := normalizeTarget(ins.Targets[i])
+		if err != nil {
+			return err
+		}
+		ins.Targets[i] = target
+	}
+
+	tlsConfig, err := ins.ClientConfig.TLSConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build redis TLS config: %v", err)
+	}
+	ins.tlsConfig = tlsConfig
+	if ins.prevStats == nil {
+		ins.prevStats = make(map[string]redisCounterSnapshot)
+	}
+	if ins.initialized == nil {
+		ins.initialized = make(map[string]bool)
+	}
+
+	return nil
+}
+
+func normalizeMasterLinkStatus(status string) (string, error) {
+	status = strings.ToLower(strings.TrimSpace(status))
+	switch status {
+	case "":
+		return "", nil
+	case "up", "down":
+		return status, nil
+	default:
+		return "", fmt.Errorf("invalid master_link_status.expect %q, must be one of: up, down", status)
+	}
+}
+
+func mergeClientConfig(dst *tlscfg.ClientConfig, src tlscfg.ClientConfig) {
+	if !dst.UseTLS {
+		dst.UseTLS = src.UseTLS
+	}
+	if dst.TLSCA == "" {
+		dst.TLSCA = src.TLSCA
+	}
+	if dst.TLSCert == "" {
+		dst.TLSCert = src.TLSCert
+	}
+	if dst.TLSKey == "" {
+		dst.TLSKey = src.TLSKey
+	}
+	if dst.TLSKeyPwd == "" {
+		dst.TLSKeyPwd = src.TLSKeyPwd
+	}
+	if !dst.InsecureSkipVerify {
+		dst.InsecureSkipVerify = src.InsecureSkipVerify
+	}
+	if dst.ServerName == "" {
+		dst.ServerName = src.ServerName
+	}
+	if dst.TLSMinVersion == "" {
+		dst.TLSMinVersion = src.TLSMinVersion
+	}
+	if dst.TLSMaxVersion == "" {
+		dst.TLSMaxVersion = src.TLSMaxVersion
+	}
+}
+
+func validateCountCheck(name string, check CountCheck) error {
+	if check.WarnGe < 0 || check.CriticalGe < 0 {
+		return fmt.Errorf("%s thresholds must be >= 0", name)
+	}
+	if check.WarnGe > 0 && check.CriticalGe > 0 && check.WarnGe >= check.CriticalGe {
+		return fmt.Errorf("%s.warn_ge(%d) must be less than %s.critical_ge(%d)",
+			name, check.WarnGe, name, check.CriticalGe)
+	}
+	return nil
+}
+
+func validateMinCountCheck(name string, check MinCountCheck) error {
+	if check.WarnLt < 0 || check.CriticalLt < 0 {
+		return fmt.Errorf("%s thresholds must be >= 0", name)
+	}
+	if check.WarnLt > 0 && check.CriticalLt > 0 && check.WarnLt <= check.CriticalLt {
+		return fmt.Errorf("%s.warn_lt(%d) must be greater than %s.critical_lt(%d)",
+			name, check.WarnLt, name, check.CriticalLt)
+	}
+	return nil
+}
+
+func normalizeRole(role string) (string, error) {
+	role = strings.ToLower(strings.TrimSpace(role))
+	switch role {
+	case "":
+		return "", nil
+	case "master":
+		return "master", nil
+	case "slave", "replica":
+		return "slave", nil
+	default:
+		return "", fmt.Errorf("invalid role.expect %q, must be one of: master, slave, replica", role)
+	}
+}
+
+func normalizeTarget(raw string) (string, error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", fmt.Errorf("redis target must not be empty")
+	}
+
+	host, port, err := net.SplitHostPort(target)
+	if err == nil {
+		if port == "" {
+			return "", fmt.Errorf("bad port, target: %s", raw)
+		}
+		if host == "" {
+			host = "localhost"
+		}
+		return net.JoinHostPort(host, port), nil
+	}
+
+	if strings.Contains(err.Error(), "missing port in address") {
+		if strings.Count(target, ":") > 1 && !strings.HasPrefix(target, "[") {
+			return "", fmt.Errorf("redis IPv6 target must use [addr]:port format: %s", raw)
+		}
+		return net.JoinHostPort(target, defaultRedisPort), nil
+	}
+
+	return "", fmt.Errorf("failed to parse redis target %q: %v", raw, err)
+}
+
+func (ins *Instance) Gather(q *safe.Queue[*types.Event]) {
+	if len(ins.Targets) == 0 {
+		return
+	}
+
+	wg := new(sync.WaitGroup)
+	se := semaphore.NewSemaphore(ins.Concurrency)
+	for _, target := range ins.Targets {
+		wg.Add(1)
+		go func(target string) {
+			se.Acquire()
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Logger.Errorw("panic in redis gather goroutine", "target", target, "recover", r)
+					q.PushFront(types.BuildEvent(map[string]string{
+						"check":  "redis::connectivity",
+						"target": target,
+					}).SetTitleRule("[TPL]${check} ${from_hostip} ${target}").
+						SetEventStatus(types.EventStatusCritical).
+						SetDescription(fmt.Sprintf("panic during check: %v", r)))
+				}
+				se.Release()
+				wg.Done()
+			}()
+			ins.gatherTarget(q, target)
+		}(target)
+	}
+	wg.Wait()
+}
+
+func (ins *Instance) gatherTarget(q *safe.Queue[*types.Event], target string) {
+	connEvent := ins.newEvent("redis::connectivity", target, ins.Connectivity.TitleRule)
+	start := time.Now()
+
+	client, err := ins.connect(target)
+	if err != nil {
+		connEvent.Labels[types.AttrPrefix+"response_time"] = time.Since(start).String()
+		q.PushFront(connEvent.SetEventStatus(ins.Connectivity.Severity).
+			SetDescription(fmt.Sprintf("redis ping failed: %v", err)))
+		return
+	}
+	defer client.Close()
+
+	if _, err := client.command("PING"); err != nil {
+		connEvent.Labels[types.AttrPrefix+"response_time"] = time.Since(start).String()
+		q.PushFront(connEvent.SetEventStatus(ins.Connectivity.Severity).
+			SetDescription(fmt.Sprintf("redis ping failed: %v", err)))
+		return
+	}
+
+	responseTime := time.Since(start)
+	connEvent.Labels[types.AttrPrefix+"response_time"] = responseTime.String()
+	q.PushFront(connEvent.SetDescription("redis ping ok"))
+
+	ins.checkResponseTime(q, target, responseTime)
+
+	infoCache := make(map[string]string)
+	infoSection := func(section string) (string, error) {
+		if info, ok := infoCache[section]; ok {
+			return info, nil
+		}
+		info, err := client.info(section)
+		if err != nil {
+			return "", err
+		}
+		infoCache[section] = info
+		return info, nil
+	}
+
+	if ins.Role.Expect != "" {
+		info, err := infoSection("replication")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::role", target, ins.Role.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to query redis replication info: %v", err)))
+		} else {
+			ins.checkRole(q, target, info)
+		}
+	}
+
+	if ins.MasterLink.Expect != "" {
+		info, err := infoSection("replication")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::master_link_status", target, ins.MasterLink.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to query redis replication info: %v", err)))
+		} else {
+			ins.checkMasterLink(q, target, info)
+		}
+	}
+
+	if ins.ConnectedSlaves.WarnLt > 0 || ins.ConnectedSlaves.CriticalLt > 0 {
+		info, err := infoSection("replication")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::connected_slaves", target, ins.ConnectedSlaves.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to query redis replication info: %v", err)))
+		} else {
+			ins.checkMinCountFromInfo(q, target, "redis::connected_slaves", info, "connected_slaves",
+				ins.ConnectedSlaves, "connected slaves")
+		}
+	}
+
+	if ins.ConnectedClients.WarnGe > 0 || ins.ConnectedClients.CriticalGe > 0 || ins.BlockedClients.WarnGe > 0 || ins.BlockedClients.CriticalGe > 0 {
+		info, err := infoSection("clients")
+		if err != nil {
+			if ins.ConnectedClients.WarnGe > 0 || ins.ConnectedClients.CriticalGe > 0 {
+				q.PushFront(ins.newEvent("redis::connected_clients", target, ins.ConnectedClients.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to query redis client info: %v", err)))
+			}
+			if ins.BlockedClients.WarnGe > 0 || ins.BlockedClients.CriticalGe > 0 {
+				q.PushFront(ins.newEvent("redis::blocked_clients", target, ins.BlockedClients.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to query redis client info: %v", err)))
+			}
+			return
+		}
+
+		if ins.ConnectedClients.WarnGe > 0 || ins.ConnectedClients.CriticalGe > 0 {
+			if value, ok, parseErr := parseInfoInt(info, "connected_clients"); parseErr != nil {
+				q.PushFront(ins.newEvent("redis::connected_clients", target, ins.ConnectedClients.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to parse redis connected_clients: %v", parseErr)))
+			} else if !ok {
+				q.PushFront(ins.newEvent("redis::connected_clients", target, ins.ConnectedClients.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription("redis info output missing connected_clients"))
+			} else {
+				ins.checkCount(q, target, "redis::connected_clients", value, ins.ConnectedClients, "connected clients")
+			}
+		}
+
+		if ins.BlockedClients.WarnGe > 0 || ins.BlockedClients.CriticalGe > 0 {
+			if value, ok, parseErr := parseInfoInt(info, "blocked_clients"); parseErr != nil {
+				q.PushFront(ins.newEvent("redis::blocked_clients", target, ins.BlockedClients.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to parse redis blocked_clients: %v", parseErr)))
+			} else if !ok {
+				q.PushFront(ins.newEvent("redis::blocked_clients", target, ins.BlockedClients.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription("redis info output missing blocked_clients"))
+			} else {
+				ins.checkCount(q, target, "redis::blocked_clients", value, ins.BlockedClients, "blocked clients")
+			}
+		}
+	}
+
+	if ins.UsedMemory.WarnGe > 0 || ins.UsedMemory.CriticalGe > 0 {
+		info, err := infoSection("memory")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::used_memory", target, ins.UsedMemory.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to query redis memory info: %v", err)))
+		} else {
+			ins.checkUsedMemory(q, target, info)
+		}
+	}
+
+	if ins.RejectedConn.WarnGe > 0 || ins.RejectedConn.CriticalGe > 0 {
+		info, err := infoSection("stats")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::rejected_connections", target, ins.RejectedConn.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to query redis stats info: %v", err)))
+		} else {
+			ins.checkCountFromInfo(q, target, "redis::rejected_connections", info, "rejected_connections",
+				ins.RejectedConn, "rejected connections")
+		}
+	}
+
+	if ins.EvictedKeys.WarnGe > 0 || ins.EvictedKeys.CriticalGe > 0 || ins.ExpiredKeys.WarnGe > 0 || ins.ExpiredKeys.CriticalGe > 0 || ins.OpsPerSecond.WarnGe > 0 || ins.OpsPerSecond.CriticalGe > 0 {
+		info, err := infoSection("stats")
+		if err != nil {
+			if ins.EvictedKeys.WarnGe > 0 || ins.EvictedKeys.CriticalGe > 0 {
+				q.PushFront(ins.newEvent("redis::evicted_keys", target, ins.EvictedKeys.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to query redis stats info: %v", err)))
+			}
+			if ins.ExpiredKeys.WarnGe > 0 || ins.ExpiredKeys.CriticalGe > 0 {
+				q.PushFront(ins.newEvent("redis::expired_keys", target, ins.ExpiredKeys.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to query redis stats info: %v", err)))
+			}
+			if ins.OpsPerSecond.WarnGe > 0 || ins.OpsPerSecond.CriticalGe > 0 {
+				q.PushFront(ins.newEvent("redis::instantaneous_ops_per_sec", target, ins.OpsPerSecond.TitleRule).
+					SetEventStatus(types.EventStatusCritical).
+					SetDescription(fmt.Sprintf("failed to query redis stats info: %v", err)))
+			}
+		} else {
+			ins.checkCounterDeltas(q, target, info)
+			if ins.OpsPerSecond.WarnGe > 0 || ins.OpsPerSecond.CriticalGe > 0 {
+				ins.checkCountFromInfo(q, target, "redis::instantaneous_ops_per_sec", info, "instantaneous_ops_per_sec",
+					CountCheck{
+						WarnGe:     ins.OpsPerSecond.WarnGe,
+						CriticalGe: ins.OpsPerSecond.CriticalGe,
+						TitleRule:  ins.OpsPerSecond.TitleRule,
+					},
+					"instantaneous ops per second")
+			}
+		}
+	}
+
+	if ins.Persistence.Enabled {
+		info, err := infoSection("persistence")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::persistence", target, ins.Persistence.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to query redis persistence info: %v", err)))
+		} else {
+			ins.checkPersistence(q, target, info)
+		}
+	}
+}
+
+func (ins *Instance) connect(target string) (*redisClient, error) {
+	var conn net.Conn
+	var err error
+
+	if ins.tlsConfig != nil {
+		cfg := ins.tlsConfig.Clone()
+		host, _, splitErr := net.SplitHostPort(target)
+		if splitErr == nil && cfg.ServerName == "" && net.ParseIP(host) == nil {
+			cfg.ServerName = host
+		}
+
+		rawConn, dialErr := ins.dialTarget("tcp", target)
+		if dialErr != nil {
+			return nil, dialErr
+		}
+
+		tlsConn := tls.Client(rawConn, cfg)
+		if err := tlsConn.SetDeadline(time.Now().Add(time.Duration(ins.Timeout))); err != nil {
+			rawConn.Close()
+			return nil, err
+		}
+		if err := tlsConn.Handshake(); err != nil {
+			rawConn.Close()
+			return nil, err
+		}
+		_ = tlsConn.SetDeadline(time.Time{})
+		conn = tlsConn
+	} else {
+		conn, err = ins.dialTarget("tcp", target)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	client := &redisClient{
+		conn:        conn,
+		reader:      bufio.NewReader(conn),
+		timeout:     time.Duration(ins.Timeout),
+		readTimeout: time.Duration(ins.ReadTimeout),
+	}
+
+	if ins.Password != "" || ins.Username != "" {
+		args := []string{"AUTH"}
+		if ins.Username != "" {
+			args = append(args, ins.Username)
+		}
+		args = append(args, ins.Password)
+		reply, err := client.command(args...)
+		if err != nil {
+			client.Close()
+			return nil, err
+		}
+		if strings.ToUpper(reply) != "OK" {
+			client.Close()
+			return nil, fmt.Errorf("unexpected AUTH reply: %q", reply)
+		}
+	}
+
+	if ins.DB > 0 {
+		reply, err := client.command("SELECT", strconv.Itoa(ins.DB))
+		if err != nil {
+			client.Close()
+			return nil, err
+		}
+		if strings.ToUpper(reply) != "OK" {
+			client.Close()
+			return nil, fmt.Errorf("unexpected SELECT reply: %q", reply)
+		}
+	}
+
+	return client, nil
+}
+
+func (ins *Instance) dialTarget(network, target string) (net.Conn, error) {
+	if ins.dialFunc != nil {
+		return ins.dialFunc(network, target)
+	}
+	dialer := &net.Dialer{Timeout: time.Duration(ins.Timeout)}
+	return dialer.Dial(network, target)
+}
+
+func (ins *Instance) checkResponseTime(q *safe.Queue[*types.Event], target string, responseTime time.Duration) {
+	if ins.ResponseTime.WarnGe == 0 && ins.ResponseTime.CriticalGe == 0 {
+		return
+	}
+
+	event := ins.newEvent("redis::response_time", target, ins.ResponseTime.TitleRule)
+	event.Labels[types.AttrPrefix+"response_time"] = responseTime.String()
+	if ins.ResponseTime.WarnGe > 0 {
+		event.Labels[types.AttrPrefix+"warn_ge"] = time.Duration(ins.ResponseTime.WarnGe).String()
+	}
+	if ins.ResponseTime.CriticalGe > 0 {
+		event.Labels[types.AttrPrefix+"critical_ge"] = time.Duration(ins.ResponseTime.CriticalGe).String()
+	}
+
+	status := types.EvaluateGeThreshold(float64(responseTime), float64(ins.ResponseTime.WarnGe), float64(ins.ResponseTime.CriticalGe))
+	switch status {
+	case types.EventStatusCritical:
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis response time %s >= critical threshold %s",
+				responseTime, time.Duration(ins.ResponseTime.CriticalGe))))
+	case types.EventStatusWarning:
+		q.PushFront(event.SetEventStatus(types.EventStatusWarning).
+			SetDescription(fmt.Sprintf("redis response time %s >= warning threshold %s",
+				responseTime, time.Duration(ins.ResponseTime.WarnGe))))
+	default:
+		q.PushFront(event.SetDescription(fmt.Sprintf("redis response time %s, everything is ok", responseTime)))
+	}
+}
+
+func (ins *Instance) checkRole(q *safe.Queue[*types.Event], target string, info string) {
+	event := ins.newEvent("redis::role", target, ins.Role.TitleRule)
+	actual, ok := parseInfoString(info, "role")
+	if !ok {
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription("redis info output missing role"))
+		return
+	}
+
+	actual = strings.ToLower(strings.TrimSpace(actual))
+	event.Labels[types.AttrPrefix+"actual"] = actual
+	event.Labels[types.AttrPrefix+"expect"] = ins.Role.Expect
+
+	if actual == ins.Role.Expect {
+		q.PushFront(event.SetDescription(fmt.Sprintf("redis role is %s, matches expectation", actual)))
+		return
+	}
+
+	q.PushFront(event.SetEventStatus(ins.Role.Severity).
+		SetDescription(fmt.Sprintf("redis role is %s, expected %s", actual, ins.Role.Expect)))
+}
+
+func (ins *Instance) checkMasterLink(q *safe.Queue[*types.Event], target string, info string) {
+	event := ins.newEvent("redis::master_link_status", target, ins.MasterLink.TitleRule)
+	role, ok := parseInfoString(info, "role")
+	if ok {
+		event.Labels[types.AttrPrefix+"role"] = role
+	}
+	actual, ok := parseInfoString(info, "master_link_status")
+	if !ok {
+		q.PushFront(event.SetEventStatus(ins.MasterLink.Severity).
+			SetDescription("redis replication info missing master_link_status"))
+		return
+	}
+
+	actual = strings.ToLower(strings.TrimSpace(actual))
+	event.Labels[types.AttrPrefix+"actual"] = actual
+	event.Labels[types.AttrPrefix+"expect"] = ins.MasterLink.Expect
+
+	if v, ok := parseInfoString(info, "master_host"); ok && v != "" {
+		event.Labels[types.AttrPrefix+"master_host"] = v
+	}
+	if v, ok := parseInfoString(info, "master_port"); ok && v != "" {
+		event.Labels[types.AttrPrefix+"master_port"] = v
+	}
+
+	if actual == ins.MasterLink.Expect {
+		q.PushFront(event.SetDescription(fmt.Sprintf("redis master link status is %s, matches expectation", actual)))
+		return
+	}
+
+	q.PushFront(event.SetEventStatus(ins.MasterLink.Severity).
+		SetDescription(fmt.Sprintf("redis master link status is %s, expected %s", actual, ins.MasterLink.Expect)))
+}
+
+func (ins *Instance) checkCount(q *safe.Queue[*types.Event], target, check string, value int, thresholds CountCheck, metricName string) {
+	event := ins.newEvent(check, target, thresholds.TitleRule)
+	labelKey := strings.TrimPrefix(check, "redis::")
+	event.Labels[types.AttrPrefix+labelKey] = strconv.Itoa(value)
+	if thresholds.WarnGe > 0 {
+		event.Labels[types.AttrPrefix+"warn_ge"] = strconv.Itoa(thresholds.WarnGe)
+	}
+	if thresholds.CriticalGe > 0 {
+		event.Labels[types.AttrPrefix+"critical_ge"] = strconv.Itoa(thresholds.CriticalGe)
+	}
+
+	status := types.EvaluateGeThreshold(float64(value), float64(thresholds.WarnGe), float64(thresholds.CriticalGe))
+	switch status {
+	case types.EventStatusCritical:
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis %s %d >= critical threshold %d", metricName, value, thresholds.CriticalGe)))
+	case types.EventStatusWarning:
+		q.PushFront(event.SetEventStatus(types.EventStatusWarning).
+			SetDescription(fmt.Sprintf("redis %s %d >= warning threshold %d", metricName, value, thresholds.WarnGe)))
+	default:
+		q.PushFront(event.SetDescription(fmt.Sprintf("redis %s %d, everything is ok", metricName, value)))
+	}
+}
+
+func (ins *Instance) checkCountFromInfo(q *safe.Queue[*types.Event], target, check, info, key string, thresholds CountCheck, metricName string) {
+	value, ok, err := parseInfoInt(info, key)
+	if err != nil {
+		q.PushFront(ins.newEvent(check, target, thresholds.TitleRule).
+			SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("failed to parse redis %s: %v", key, err)))
+		return
+	}
+	if !ok {
+		q.PushFront(ins.newEvent(check, target, thresholds.TitleRule).
+			SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis info output missing %s", key)))
+		return
+	}
+	ins.checkCount(q, target, check, value, thresholds, metricName)
+}
+
+func (ins *Instance) checkMinCountFromInfo(q *safe.Queue[*types.Event], target, check, info, key string, thresholds MinCountCheck, metricName string) {
+	value, ok, err := parseInfoInt(info, key)
+	if err != nil {
+		q.PushFront(ins.newEvent(check, target, thresholds.TitleRule).
+			SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("failed to parse redis %s: %v", key, err)))
+		return
+	}
+	if !ok {
+		q.PushFront(ins.newEvent(check, target, thresholds.TitleRule).
+			SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis info output missing %s", key)))
+		return
+	}
+	ins.checkMinCount(q, target, check, value, thresholds, metricName)
+}
+
+func (ins *Instance) checkMinCount(q *safe.Queue[*types.Event], target, check string, value int, thresholds MinCountCheck, metricName string) {
+	event := ins.newEvent(check, target, thresholds.TitleRule)
+	labelKey := strings.TrimPrefix(check, "redis::")
+	event.Labels[types.AttrPrefix+labelKey] = strconv.Itoa(value)
+	if thresholds.WarnLt > 0 {
+		event.Labels[types.AttrPrefix+"warn_lt"] = strconv.Itoa(thresholds.WarnLt)
+	}
+	if thresholds.CriticalLt > 0 {
+		event.Labels[types.AttrPrefix+"critical_lt"] = strconv.Itoa(thresholds.CriticalLt)
+	}
+
+	if thresholds.CriticalLt > 0 && value < thresholds.CriticalLt {
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis %s %d < critical threshold %d", metricName, value, thresholds.CriticalLt)))
+		return
+	}
+	if thresholds.WarnLt > 0 && value < thresholds.WarnLt {
+		q.PushFront(event.SetEventStatus(types.EventStatusWarning).
+			SetDescription(fmt.Sprintf("redis %s %d < warning threshold %d", metricName, value, thresholds.WarnLt)))
+		return
+	}
+	q.PushFront(event.SetDescription(fmt.Sprintf("redis %s %d, everything is ok", metricName, value)))
+}
+
+func (ins *Instance) checkCounterDeltas(q *safe.Queue[*types.Event], target, info string) {
+	var (
+		evicted uint64
+		expired uint64
+	)
+
+	if ins.EvictedKeys.WarnGe > 0 || ins.EvictedKeys.CriticalGe > 0 {
+		value, ok, err := parseInfoUint64(info, "evicted_keys")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::evicted_keys", target, ins.EvictedKeys.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to parse redis evicted_keys: %v", err)))
+			return
+		}
+		if !ok {
+			q.PushFront(ins.newEvent("redis::evicted_keys", target, ins.EvictedKeys.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription("redis info output missing evicted_keys"))
+			return
+		}
+		evicted = value
+	}
+
+	if ins.ExpiredKeys.WarnGe > 0 || ins.ExpiredKeys.CriticalGe > 0 {
+		value, ok, err := parseInfoUint64(info, "expired_keys")
+		if err != nil {
+			q.PushFront(ins.newEvent("redis::expired_keys", target, ins.ExpiredKeys.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription(fmt.Sprintf("failed to parse redis expired_keys: %v", err)))
+			return
+		}
+		if !ok {
+			q.PushFront(ins.newEvent("redis::expired_keys", target, ins.ExpiredKeys.TitleRule).
+				SetEventStatus(types.EventStatusCritical).
+				SetDescription("redis info output missing expired_keys"))
+			return
+		}
+		expired = value
+	}
+
+	ins.statsMu.Lock()
+	prev := ins.prevStats[target]
+	initialized := ins.initialized[target]
+	ins.prevStats[target] = redisCounterSnapshot{
+		evictedKeys: evicted,
+		expiredKeys: expired,
+	}
+	ins.initialized[target] = true
+	ins.statsMu.Unlock()
+
+	if !initialized {
+		if ins.EvictedKeys.WarnGe > 0 || ins.EvictedKeys.CriticalGe > 0 {
+			event := ins.newEvent("redis::evicted_keys", target, ins.EvictedKeys.TitleRule)
+			event.Labels[types.AttrPrefix+"delta"] = "0"
+			event.Labels[types.AttrPrefix+"total"] = strconv.FormatUint(evicted, 10)
+			q.PushFront(event.SetDescription(fmt.Sprintf("redis evicted keys baseline established (total: %d)", evicted)))
+		}
+		if ins.ExpiredKeys.WarnGe > 0 || ins.ExpiredKeys.CriticalGe > 0 {
+			event := ins.newEvent("redis::expired_keys", target, ins.ExpiredKeys.TitleRule)
+			event.Labels[types.AttrPrefix+"delta"] = "0"
+			event.Labels[types.AttrPrefix+"total"] = strconv.FormatUint(expired, 10)
+			q.PushFront(event.SetDescription(fmt.Sprintf("redis expired keys baseline established (total: %d)", expired)))
+		}
+		return
+	}
+
+	if ins.EvictedKeys.WarnGe > 0 || ins.EvictedKeys.CriticalGe > 0 {
+		delta := uint64(0)
+		if evicted >= prev.evictedKeys {
+			delta = evicted - prev.evictedKeys
+		}
+		ins.checkDeltaCount(q, target, "redis::evicted_keys", delta, evicted, ins.EvictedKeys, "evicted keys")
+	}
+
+	if ins.ExpiredKeys.WarnGe > 0 || ins.ExpiredKeys.CriticalGe > 0 {
+		delta := uint64(0)
+		if expired >= prev.expiredKeys {
+			delta = expired - prev.expiredKeys
+		}
+		ins.checkDeltaCount(q, target, "redis::expired_keys", delta, expired, ins.ExpiredKeys, "expired keys")
+	}
+}
+
+func (ins *Instance) checkDeltaCount(q *safe.Queue[*types.Event], target, check string, delta, total uint64, thresholds CountCheck, metricName string) {
+	event := ins.newEvent(check, target, thresholds.TitleRule)
+	event.Labels[types.AttrPrefix+"delta"] = strconv.FormatUint(delta, 10)
+	event.Labels[types.AttrPrefix+"total"] = strconv.FormatUint(total, 10)
+	if thresholds.WarnGe > 0 {
+		event.Labels[types.AttrPrefix+"warn_ge"] = strconv.Itoa(thresholds.WarnGe)
+	}
+	if thresholds.CriticalGe > 0 {
+		event.Labels[types.AttrPrefix+"critical_ge"] = strconv.Itoa(thresholds.CriticalGe)
+	}
+
+	status := types.EvaluateGeThreshold(float64(delta), float64(thresholds.WarnGe), float64(thresholds.CriticalGe))
+	switch status {
+	case types.EventStatusCritical:
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis %s delta %d >= critical threshold %d", metricName, delta, thresholds.CriticalGe)))
+	case types.EventStatusWarning:
+		q.PushFront(event.SetEventStatus(types.EventStatusWarning).
+			SetDescription(fmt.Sprintf("redis %s delta %d >= warning threshold %d", metricName, delta, thresholds.WarnGe)))
+	default:
+		q.PushFront(event.SetDescription(fmt.Sprintf("redis %s delta %d, everything is ok", metricName, delta)))
+	}
+}
+
+func (ins *Instance) checkUsedMemory(q *safe.Queue[*types.Event], target string, info string) {
+	event := ins.newEvent("redis::used_memory", target, ins.UsedMemory.TitleRule)
+	usedMemory, ok, err := parseInfoInt64(info, "used_memory")
+	if err != nil {
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("failed to parse redis used_memory: %v", err)))
+		return
+	}
+	if !ok {
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription("redis info output missing used_memory"))
+		return
+	}
+
+	event.Labels[types.AttrPrefix+"used_memory"] = conv.HumanBytes(uint64(usedMemory))
+	event.Labels[types.AttrPrefix+"used_memory_bytes"] = strconv.FormatInt(usedMemory, 10)
+	if ins.UsedMemory.WarnGe > 0 {
+		event.Labels[types.AttrPrefix+"warn_ge"] = ins.UsedMemory.WarnGe.String()
+	}
+	if ins.UsedMemory.CriticalGe > 0 {
+		event.Labels[types.AttrPrefix+"critical_ge"] = ins.UsedMemory.CriticalGe.String()
+	}
+	if maxmemory, ok, err := parseInfoInt64(info, "maxmemory"); err == nil && ok && maxmemory > 0 {
+		event.Labels[types.AttrPrefix+"maxmemory"] = conv.HumanBytes(uint64(maxmemory))
+		event.Labels[types.AttrPrefix+"maxmemory_bytes"] = strconv.FormatInt(maxmemory, 10)
+		event.Labels[types.AttrPrefix+"used_percent_of_maxmemory"] = fmt.Sprintf("%.1f%%", float64(usedMemory)*100/float64(maxmemory))
+	}
+
+	status := types.EvaluateGeThreshold(float64(usedMemory), float64(ins.UsedMemory.WarnGe), float64(ins.UsedMemory.CriticalGe))
+	switch status {
+	case types.EventStatusCritical:
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("redis used memory %s >= critical threshold %s",
+				conv.HumanBytes(uint64(usedMemory)), ins.UsedMemory.CriticalGe.String())))
+	case types.EventStatusWarning:
+		q.PushFront(event.SetEventStatus(types.EventStatusWarning).
+			SetDescription(fmt.Sprintf("redis used memory %s >= warning threshold %s",
+				conv.HumanBytes(uint64(usedMemory)), ins.UsedMemory.WarnGe.String())))
+	default:
+		q.PushFront(event.SetDescription(fmt.Sprintf("redis used memory %s, everything is ok", conv.HumanBytes(uint64(usedMemory)))))
+	}
+}
+
+func (ins *Instance) checkPersistence(q *safe.Queue[*types.Event], target string, info string) {
+	event := ins.newEvent("redis::persistence", target, ins.Persistence.TitleRule)
+
+	loading, ok, err := parseInfoInt(info, "loading")
+	if err != nil {
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription(fmt.Sprintf("failed to parse redis loading state: %v", err)))
+		return
+	}
+	if !ok {
+		q.PushFront(event.SetEventStatus(types.EventStatusCritical).
+			SetDescription("redis persistence info missing loading"))
+		return
+	}
+
+	event.Labels[types.AttrPrefix+"loading"] = strconv.Itoa(loading)
+	if v, ok := parseInfoString(info, "rdb_last_bgsave_status"); ok {
+		event.Labels[types.AttrPrefix+"rdb_last_bgsave_status"] = v
+	}
+	if v, ok := parseInfoString(info, "aof_enabled"); ok {
+		event.Labels[types.AttrPrefix+"aof_enabled"] = v
+	}
+	if v, ok := parseInfoString(info, "aof_last_write_status"); ok {
+		event.Labels[types.AttrPrefix+"aof_last_write_status"] = v
+	}
+	if v, ok := parseInfoString(info, "rdb_bgsave_in_progress"); ok {
+		event.Labels[types.AttrPrefix+"rdb_bgsave_in_progress"] = v
+	}
+	if v, ok := parseInfoString(info, "aof_rewrite_in_progress"); ok {
+		event.Labels[types.AttrPrefix+"aof_rewrite_in_progress"] = v
+	}
+
+	if loading == 1 {
+		q.PushFront(event.SetEventStatus(ins.Persistence.Severity).
+			SetDescription("redis is loading persistence data"))
+		return
+	}
+
+	if status, ok := parseInfoString(info, "rdb_last_bgsave_status"); ok && status != "" && strings.ToLower(status) != "ok" {
+		q.PushFront(event.SetEventStatus(ins.Persistence.Severity).
+			SetDescription(fmt.Sprintf("redis RDB last bgsave status is %s", status)))
+		return
+	}
+
+	aofEnabled, ok := parseInfoString(info, "aof_enabled")
+	if ok && aofEnabled == "1" {
+		if status, ok := parseInfoString(info, "aof_last_write_status"); ok && status != "" && strings.ToLower(status) != "ok" {
+			q.PushFront(event.SetEventStatus(ins.Persistence.Severity).
+				SetDescription(fmt.Sprintf("redis AOF last write status is %s", status)))
+			return
+		}
+	}
+
+	q.PushFront(event.SetDescription("redis persistence status is healthy"))
+}
+
+func (ins *Instance) newEvent(check, target, titleRule string) *types.Event {
+	if titleRule == "" {
+		titleRule = "[TPL]${check} ${from_hostip} ${target}"
+	}
+	return types.BuildEvent(map[string]string{
+		"check":  check,
+		"target": target,
+	}).SetTitleRule(titleRule)
+}
+
+type redisClient struct {
+	conn        net.Conn
+	reader      *bufio.Reader
+	timeout     time.Duration
+	readTimeout time.Duration
+}
+
+func (c *redisClient) Close() error {
+	return c.conn.Close()
+}
+
+func (c *redisClient) info(section string) (string, error) {
+	reply, err := c.command("INFO", section)
+	if err != nil {
+		return "", err
+	}
+	return reply, nil
+}
+
+func (c *redisClient) command(args ...string) (string, error) {
+	if err := c.writeCommand(args...); err != nil {
+		return "", err
+	}
+	reply, err := c.readReply()
+	if err != nil {
+		return "", err
+	}
+
+	switch v := reply.(type) {
+	case string:
+		return v, nil
+	case nil:
+		return "", nil
+	default:
+		return "", fmt.Errorf("unsupported redis reply type %T", reply)
+	}
+}
+
+func (c *redisClient) writeCommand(args ...string) error {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
+		return err
+	}
+
+	var b strings.Builder
+	b.WriteString("*")
+	b.WriteString(strconv.Itoa(len(args)))
+	b.WriteString("\r\n")
+	for _, arg := range args {
+		b.WriteString("$")
+		b.WriteString(strconv.Itoa(len(arg)))
+		b.WriteString("\r\n")
+		b.WriteString(arg)
+		b.WriteString("\r\n")
+	}
+
+	_, err := c.conn.Write([]byte(b.String()))
+	return err
+}
+
+func (c *redisClient) readReply() (any, error) {
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
+		return nil, err
+	}
+
+	prefix, err := c.reader.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+
+	switch prefix {
+	case '+':
+		line, err := c.readLine()
+		if err != nil {
+			return nil, err
+		}
+		return line, nil
+	case '-':
+		line, err := c.readLine()
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New(line)
+	case ':':
+		line, err := c.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return strconv.FormatInt(n, 10), nil
+	case '$':
+		line, err := c.readLine()
+		if err != nil {
+			return nil, err
+		}
+		size, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, err
+		}
+		if size < 0 {
+			return nil, nil
+		}
+		buf := make([]byte, size+2)
+		if _, err := ioReadFull(c.reader, buf); err != nil {
+			return nil, err
+		}
+		return string(buf[:size]), nil
+	default:
+		return nil, fmt.Errorf("unsupported redis reply prefix %q", prefix)
+	}
+}
+
+func (c *redisClient) readLine() (string, error) {
+	line, err := c.reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r"), nil
+}
+
+func ioReadFull(r *bufio.Reader, buf []byte) (int, error) {
+	read := 0
+	for read < len(buf) {
+		n, err := r.Read(buf[read:])
+		read += n
+		if err != nil {
+			return read, err
+		}
+	}
+	return read, nil
+}
+
+func parseInfoString(info, key string) (string, bool) {
+	prefix := key + ":"
+	for _, line := range strings.Split(info, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), true
+		}
+	}
+	return "", false
+}
+
+func parseInfoInt(info, key string) (int, bool, error) {
+	value, ok := parseInfoString(info, key)
+	if !ok {
+		return 0, false, nil
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, true, err
+	}
+	return n, true, nil
+}
+
+func parseInfoInt64(info, key string) (int64, bool, error) {
+	value, ok := parseInfoString(info, key)
+	if !ok {
+		return 0, false, nil
+	}
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, true, err
+	}
+	return n, true, nil
+}
+
+func parseInfoUint64(info, key string) (uint64, bool, error) {
+	value, ok := parseInfoString(info, key)
+	if !ok {
+		return 0, false, nil
+	}
+	n, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, true, err
+	}
+	return n, true, nil
+}

--- a/plugins/redis/redis_test.go
+++ b/plugins/redis/redis_test.go
@@ -1,0 +1,644 @@
+package redis
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cprobe/catpaw/config"
+	clogger "github.com/cprobe/catpaw/logger"
+	"github.com/cprobe/catpaw/pkg/safe"
+	tlscfg "github.com/cprobe/catpaw/pkg/tls"
+	"github.com/cprobe/catpaw/types"
+	"go.uber.org/zap"
+)
+
+func initTestConfig(t *testing.T) {
+	t.Helper()
+	if config.Config == nil {
+		tmpDir := t.TempDir()
+		config.Config = &config.ConfigType{
+			ConfigDir: tmpDir,
+			StateDir:  tmpDir,
+		}
+	}
+	if clogger.Logger == nil {
+		l, _ := zap.NewDevelopment()
+		clogger.Logger = l.Sugar()
+	}
+}
+
+type fakeRedisServer struct {
+	mu  sync.RWMutex
+	cfg fakeRedisConfig
+}
+
+type fakeRedisConfig struct {
+	username         string
+	password         string
+	role             string
+	masterLinkStatus string
+	masterHost       string
+	masterPort       string
+	connectedSlaves  int
+	connectedClients int
+	blockedClients   int
+	rejectedConn     int
+	evictedKeys      uint64
+	expiredKeys      uint64
+	opsPerSecond     int
+	usedMemory       int64
+	maxMemory        int64
+	loading          int
+	rdbLastBgsave    string
+	rdbInProgress    int
+	aofEnabled       int
+	aofLastWrite     string
+	aofRewrite       int
+	pingDelay        time.Duration
+}
+
+func startFakeRedisServer(t *testing.T, cfg fakeRedisConfig) *fakeRedisServer {
+	t.Helper()
+	return &fakeRedisServer{cfg: cfg}
+}
+
+func (s *fakeRedisServer) Close() {
+}
+
+func (s *fakeRedisServer) Dial(network, address string) (net.Conn, error) {
+	client, server := net.Pipe()
+	go s.handleConn(server)
+	return client, nil
+}
+
+func (s *fakeRedisServer) SetConfig(cfg fakeRedisConfig) {
+	s.mu.Lock()
+	s.cfg = cfg
+	s.mu.Unlock()
+}
+
+func (s *fakeRedisServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	s.mu.RLock()
+	cfg := s.cfg
+	s.mu.RUnlock()
+	authed := cfg.password == ""
+
+	for {
+		args, err := readRESPArray(reader)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			return
+		}
+
+		cmd := strings.ToUpper(args[0])
+		if !authed && cmd != "AUTH" {
+			writeRESPError(conn, "NOAUTH Authentication required.")
+			continue
+		}
+
+		switch cmd {
+		case "AUTH":
+			if cfg.username != "" {
+				if len(args) != 3 || args[1] != cfg.username || args[2] != cfg.password {
+					writeRESPError(conn, "WRONGPASS invalid username-password pair")
+					continue
+				}
+			} else {
+				if len(args) != 2 || args[1] != cfg.password {
+					writeRESPError(conn, "WRONGPASS invalid password")
+					continue
+				}
+			}
+			authed = true
+			writeRESPSimpleString(conn, "OK")
+		case "SELECT":
+			writeRESPSimpleString(conn, "OK")
+		case "PING":
+			if cfg.pingDelay > 0 {
+				time.Sleep(cfg.pingDelay)
+			}
+			writeRESPSimpleString(conn, "PONG")
+		case "INFO":
+			section := ""
+			if len(args) > 1 {
+				section = strings.ToLower(args[1])
+			}
+			switch section {
+			case "replication":
+				writeRESPBulkString(conn, fmt.Sprintf("# Replication\r\nrole:%s\r\nmaster_link_status:%s\r\nmaster_host:%s\r\nmaster_port:%s\r\nconnected_slaves:%d\r\n",
+					cfg.role, cfg.masterLinkStatus, cfg.masterHost, cfg.masterPort, cfg.connectedSlaves))
+			case "clients":
+				writeRESPBulkString(conn, fmt.Sprintf("# Clients\r\nconnected_clients:%d\r\nblocked_clients:%d\r\n",
+					cfg.connectedClients, cfg.blockedClients))
+			case "memory":
+				writeRESPBulkString(conn, fmt.Sprintf("# Memory\r\nused_memory:%d\r\nmaxmemory:%d\r\n",
+					cfg.usedMemory, cfg.maxMemory))
+			case "stats":
+				writeRESPBulkString(conn, fmt.Sprintf("# Stats\r\nrejected_connections:%d\r\nevicted_keys:%d\r\nexpired_keys:%d\r\ninstantaneous_ops_per_sec:%d\r\n",
+					cfg.rejectedConn, cfg.evictedKeys, cfg.expiredKeys, cfg.opsPerSecond))
+			case "persistence":
+				writeRESPBulkString(conn, fmt.Sprintf("# Persistence\r\nloading:%d\r\nrdb_last_bgsave_status:%s\r\nrdb_bgsave_in_progress:%d\r\naof_enabled:%d\r\naof_last_write_status:%s\r\naof_rewrite_in_progress:%d\r\n",
+					cfg.loading, cfg.rdbLastBgsave, cfg.rdbInProgress, cfg.aofEnabled, cfg.aofLastWrite, cfg.aofRewrite))
+			default:
+				writeRESPBulkString(conn, "")
+			}
+		default:
+			writeRESPError(conn, "ERR unknown command")
+		}
+	}
+}
+
+func readRESPArray(r *bufio.Reader) ([]string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("expected array, got %q", line)
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(line, "*"))
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		hdr, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		hdr = strings.TrimSuffix(strings.TrimSuffix(hdr, "\n"), "\r")
+		if !strings.HasPrefix(hdr, "$") {
+			return nil, fmt.Errorf("expected bulk string, got %q", hdr)
+		}
+		size, err := strconv.Atoi(strings.TrimPrefix(hdr, "$"))
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, size+2)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		ret = append(ret, string(buf[:size]))
+	}
+
+	return ret, nil
+}
+
+func writeRESPSimpleString(conn net.Conn, s string) {
+	_, _ = conn.Write([]byte("+" + s + "\r\n"))
+}
+
+func writeRESPError(conn net.Conn, s string) {
+	_, _ = conn.Write([]byte("-" + s + "\r\n"))
+}
+
+func writeRESPBulkString(conn net.Conn, s string) {
+	_, _ = conn.Write([]byte(fmt.Sprintf("$%d\r\n%s\r\n", len(s), s)))
+}
+
+func collectByCheck(events []*types.Event) map[string]*types.Event {
+	ret := make(map[string]*types.Event, len(events))
+	for _, event := range events {
+		ret[event.Labels["check"]] = event
+	}
+	return ret
+}
+
+func TestInitValidation(t *testing.T) {
+	initTestConfig(t)
+
+	tests := []struct {
+		name    string
+		ins     *Instance
+		wantErr string
+	}{
+		{
+			name: "invalid role",
+			ins: &Instance{
+				Targets: []string{"127.0.0.1"},
+				Role: RoleCheck{
+					Expect: "sentinel",
+				},
+			},
+			wantErr: "invalid role.expect",
+		},
+		{
+			name: "bad response time threshold",
+			ins: &Instance{
+				Targets: []string{"127.0.0.1"},
+				ResponseTime: ResponseTimeCheck{
+					WarnGe:     config.Duration(2 * time.Second),
+					CriticalGe: config.Duration(time.Second),
+				},
+			},
+			wantErr: "response_time.warn_ge",
+		},
+		{
+			name: "negative db",
+			ins: &Instance{
+				Targets: []string{"127.0.0.1"},
+				DB:      -1,
+			},
+			wantErr: "db must be >= 0",
+		},
+		{
+			name: "invalid master link status",
+			ins: &Instance{
+				Targets: []string{"127.0.0.1"},
+				MasterLink: MasterLinkCheck{
+					Expect: "broken",
+				},
+			},
+			wantErr: "invalid master_link_status.expect",
+		},
+		{
+			name: "bad ops threshold",
+			ins: &Instance{
+				Targets: []string{"127.0.0.1"},
+				OpsPerSecond: OpsPerSecondCheck{
+					WarnGe:     100,
+					CriticalGe: 10,
+				},
+			},
+			wantErr: "instantaneous_ops_per_sec.warn_ge",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ins.Init()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestInitDefaultsAndNormalization(t *testing.T) {
+	initTestConfig(t)
+
+	ins := &Instance{
+		Targets: []string{"127.0.0.1"},
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	if ins.Targets[0] != "127.0.0.1:6379" {
+		t.Fatalf("expected default redis port, got %s", ins.Targets[0])
+	}
+	if ins.Concurrency != 10 {
+		t.Fatalf("expected concurrency 10, got %d", ins.Concurrency)
+	}
+	if time.Duration(ins.Timeout) != 3*time.Second {
+		t.Fatalf("expected timeout 3s, got %s", time.Duration(ins.Timeout))
+	}
+	if time.Duration(ins.ReadTimeout) != 2*time.Second {
+		t.Fatalf("expected read_timeout 2s, got %s", time.Duration(ins.ReadTimeout))
+	}
+}
+
+func TestGatherSuccess(t *testing.T) {
+	initTestConfig(t)
+
+	srv := startFakeRedisServer(t, fakeRedisConfig{
+		password:         "secret",
+		role:             "master",
+		masterLinkStatus: "up",
+		connectedSlaves:  2,
+		connectedClients: 120,
+		blockedClients:   3,
+		rejectedConn:     12,
+		evictedKeys:      100,
+		expiredKeys:      200,
+		opsPerSecond:     5000,
+		usedMemory:       256 * 1024 * 1024,
+		maxMemory:        512 * 1024 * 1024,
+		loading:          0,
+		rdbLastBgsave:    "ok",
+		aofEnabled:       1,
+		aofLastWrite:     "ok",
+		pingDelay:        30 * time.Millisecond,
+	})
+	defer srv.Close()
+
+	ins := &Instance{
+		Targets:     []string{"redis.local:6379"},
+		Password:    "secret",
+		DB:          1,
+		ReadTimeout: config.Duration(time.Second),
+		ResponseTime: ResponseTimeCheck{
+			WarnGe:     config.Duration(5 * time.Millisecond),
+			CriticalGe: config.Duration(20 * time.Millisecond),
+		},
+		Role: RoleCheck{
+			Expect:   "master",
+			Severity: types.EventStatusWarning,
+		},
+		ConnectedClients: CountCheck{
+			WarnGe:     100,
+			CriticalGe: 200,
+		},
+		BlockedClients: CountCheck{
+			WarnGe:     1,
+			CriticalGe: 2,
+		},
+		UsedMemory: MemoryUsageCheck{
+			WarnGe:     config.Size(128 * 1024 * 1024),
+			CriticalGe: config.Size(512 * 1024 * 1024),
+		},
+		RejectedConn: CountCheck{
+			WarnGe:     10,
+			CriticalGe: 20,
+		},
+		ConnectedSlaves: MinCountCheck{
+			WarnLt:     3,
+			CriticalLt: 1,
+		},
+		EvictedKeys: CountCheck{
+			WarnGe:     1,
+			CriticalGe: 5,
+		},
+		ExpiredKeys: CountCheck{
+			WarnGe:     1,
+			CriticalGe: 5,
+		},
+		OpsPerSecond: OpsPerSecondCheck{
+			WarnGe:     1000,
+			CriticalGe: 10000,
+		},
+		Persistence: PersistenceCheck{
+			Enabled:  true,
+			Severity: types.EventStatusCritical,
+		},
+		dialFunc: srv.Dial,
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	q := safe.NewQueue[*types.Event]()
+	ins.Gather(q)
+	_ = q.PopBackAll()
+
+	srv.SetConfig(fakeRedisConfig{
+		password:         "secret",
+		role:             "master",
+		masterLinkStatus: "up",
+		connectedSlaves:  2,
+		connectedClients: 120,
+		blockedClients:   3,
+		rejectedConn:     12,
+		evictedKeys:      107,
+		expiredKeys:      202,
+		opsPerSecond:     5000,
+		usedMemory:       256 * 1024 * 1024,
+		maxMemory:        512 * 1024 * 1024,
+		loading:          0,
+		rdbLastBgsave:    "ok",
+		aofEnabled:       1,
+		aofLastWrite:     "ok",
+		pingDelay:        30 * time.Millisecond,
+	})
+	q = safe.NewQueue[*types.Event]()
+	ins.Gather(q)
+	events := q.PopBackAll()
+	if len(events) != 12 {
+		t.Fatalf("expected 12 events, got %d", len(events))
+	}
+
+	byCheck := collectByCheck(events)
+
+	if byCheck["redis::connectivity"].EventStatus != types.EventStatusOk {
+		t.Fatalf("connectivity: expected Ok, got %s", byCheck["redis::connectivity"].EventStatus)
+	}
+	if byCheck["redis::response_time"].EventStatus != types.EventStatusCritical {
+		t.Fatalf("response_time: expected Critical, got %s", byCheck["redis::response_time"].EventStatus)
+	}
+	if byCheck["redis::role"].EventStatus != types.EventStatusOk {
+		t.Fatalf("role: expected Ok, got %s", byCheck["redis::role"].EventStatus)
+	}
+	if byCheck["redis::connected_clients"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("connected_clients: expected Warning, got %s", byCheck["redis::connected_clients"].EventStatus)
+	}
+	if byCheck["redis::blocked_clients"].EventStatus != types.EventStatusCritical {
+		t.Fatalf("blocked_clients: expected Critical, got %s", byCheck["redis::blocked_clients"].EventStatus)
+	}
+	if byCheck["redis::used_memory"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("used_memory: expected Warning, got %s", byCheck["redis::used_memory"].EventStatus)
+	}
+	if byCheck["redis::rejected_connections"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("rejected_connections: expected Warning, got %s", byCheck["redis::rejected_connections"].EventStatus)
+	}
+	if byCheck["redis::connected_slaves"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("connected_slaves: expected Warning, got %s", byCheck["redis::connected_slaves"].EventStatus)
+	}
+	if byCheck["redis::evicted_keys"].EventStatus != types.EventStatusCritical {
+		t.Fatalf("evicted_keys: expected Critical, got %s", byCheck["redis::evicted_keys"].EventStatus)
+	}
+	if byCheck["redis::expired_keys"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("expired_keys: expected Warning, got %s", byCheck["redis::expired_keys"].EventStatus)
+	}
+	if byCheck["redis::instantaneous_ops_per_sec"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("instantaneous_ops_per_sec: expected Warning, got %s", byCheck["redis::instantaneous_ops_per_sec"].EventStatus)
+	}
+	if byCheck["redis::persistence"].EventStatus != types.EventStatusOk {
+		t.Fatalf("persistence: expected Ok, got %s", byCheck["redis::persistence"].EventStatus)
+	}
+}
+
+func TestGatherAuthFailure(t *testing.T) {
+	initTestConfig(t)
+
+	srv := startFakeRedisServer(t, fakeRedisConfig{
+		password: "secret",
+		role:     "master",
+	})
+	defer srv.Close()
+
+	ins := &Instance{
+		Targets:  []string{"redis.local:6379"},
+		Password: "wrong",
+		dialFunc: srv.Dial,
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	q := safe.NewQueue[*types.Event]()
+	ins.Gather(q)
+	events := q.PopBackAll()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Labels["check"] != "redis::connectivity" {
+		t.Fatalf("expected connectivity event, got %s", events[0].Labels["check"])
+	}
+	if events[0].EventStatus != types.EventStatusCritical {
+		t.Fatalf("expected Critical, got %s", events[0].EventStatus)
+	}
+	if !strings.Contains(events[0].Description, "WRONGPASS") {
+		t.Fatalf("expected WRONGPASS in description, got %s", events[0].Description)
+	}
+}
+
+func TestGatherRoleMismatch(t *testing.T) {
+	initTestConfig(t)
+
+	srv := startFakeRedisServer(t, fakeRedisConfig{
+		role:             "slave",
+		masterLinkStatus: "down",
+	})
+	defer srv.Close()
+
+	ins := &Instance{
+		Targets: []string{"redis.local:6379"},
+		Role: RoleCheck{
+			Expect:   "master",
+			Severity: types.EventStatusWarning,
+		},
+		MasterLink: MasterLinkCheck{
+			Expect:   "up",
+			Severity: types.EventStatusWarning,
+		},
+		dialFunc: srv.Dial,
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	q := safe.NewQueue[*types.Event]()
+	ins.Gather(q)
+	events := q.PopBackAll()
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	byCheck := collectByCheck(events)
+	if byCheck["redis::connectivity"].EventStatus != types.EventStatusOk {
+		t.Fatalf("connectivity: expected Ok, got %s", byCheck["redis::connectivity"].EventStatus)
+	}
+	if byCheck["redis::role"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("role: expected Warning, got %s", byCheck["redis::role"].EventStatus)
+	}
+	if byCheck["redis::master_link_status"].EventStatus != types.EventStatusWarning {
+		t.Fatalf("master_link_status: expected Warning, got %s", byCheck["redis::master_link_status"].EventStatus)
+	}
+}
+
+func TestGatherPersistenceFailure(t *testing.T) {
+	initTestConfig(t)
+
+	srv := startFakeRedisServer(t, fakeRedisConfig{
+		role:          "master",
+		loading:       0,
+		rdbLastBgsave: "err",
+		aofEnabled:    1,
+		aofLastWrite:  "ok",
+	})
+	defer srv.Close()
+
+	ins := &Instance{
+		Targets: []string{"redis.local:6379"},
+		Persistence: PersistenceCheck{
+			Enabled:  true,
+			Severity: types.EventStatusCritical,
+		},
+		dialFunc: srv.Dial,
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	q := safe.NewQueue[*types.Event]()
+	ins.Gather(q)
+	events := q.PopBackAll()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	byCheck := collectByCheck(events)
+	if byCheck["redis::persistence"].EventStatus != types.EventStatusCritical {
+		t.Fatalf("persistence: expected Critical, got %s", byCheck["redis::persistence"].EventStatus)
+	}
+}
+
+func TestGatherDeltaCountersBaseline(t *testing.T) {
+	initTestConfig(t)
+
+	srv := startFakeRedisServer(t, fakeRedisConfig{
+		role:        "master",
+		evictedKeys: 10,
+		expiredKeys: 20,
+	})
+	defer srv.Close()
+
+	ins := &Instance{
+		Targets: []string{"redis.local:6379"},
+		EvictedKeys: CountCheck{
+			WarnGe:     1,
+			CriticalGe: 5,
+		},
+		ExpiredKeys: CountCheck{
+			WarnGe:     1,
+			CriticalGe: 5,
+		},
+		dialFunc: srv.Dial,
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	q := safe.NewQueue[*types.Event]()
+	ins.Gather(q)
+	events := q.PopBackAll()
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	byCheck := collectByCheck(events)
+	if byCheck["redis::evicted_keys"].EventStatus != types.EventStatusOk {
+		t.Fatalf("evicted_keys baseline: expected Ok, got %s", byCheck["redis::evicted_keys"].EventStatus)
+	}
+	if byCheck["redis::expired_keys"].EventStatus != types.EventStatusOk {
+		t.Fatalf("expired_keys baseline: expected Ok, got %s", byCheck["redis::expired_keys"].EventStatus)
+	}
+}
+
+func TestInitTLSConfig(t *testing.T) {
+	initTestConfig(t)
+
+	ins := &Instance{
+		Targets: []string{"redis.internal"},
+		ClientConfig: tlscfg.ClientConfig{
+			UseTLS: true,
+		},
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if ins.tlsConfig == nil {
+		t.Fatal("expected tls config to be initialized")
+	}
+	if _, ok := any(ins.tlsConfig).(*tls.Config); !ok {
+		t.Fatal("expected stdlib tls.Config")
+	}
+}


### PR DESCRIPTION
## Summary
- add a Redis monitoring plugin with connectivity, response time, replication, client, memory, throughput, and persistence checks
- add a default Redis plugin config under conf.d/p.redis
- add Redis plugin tests covering auth, role mismatch, persistence, and counter baseline behavior

## Testing
- GOCACHE=/tmp/catpaw-go-cache go test ./plugins/redis