### PR TITLE
feat: add etcd monitoring plugin

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/cprobe/catpaw/plugins/diskio"
 	_ "github.com/cprobe/catpaw/plugins/dns"
 	_ "github.com/cprobe/catpaw/plugins/docker"
+	_ "github.com/cprobe/catpaw/plugins/etcd"
 	_ "github.com/cprobe/catpaw/plugins/exec"
 	_ "github.com/cprobe/catpaw/plugins/filecheck"
 	_ "github.com/cprobe/catpaw/plugins/filefd"

--- a/conf.d/p.etcd/etcd.toml
+++ b/conf.d/p.etcd/etcd.toml
@@ -1,0 +1,224 @@
+# =============================================================================
+#  catpaw etcd 插件配置
+# =============================================================================
+#
+#  一个 catpaw 实例即可监控整个 etcd 集群，targets 中列出所有成员地址即可。
+#
+#  检查信号分 5 层（L1-L4 默认 ON，L5 需配置阈值才生效）：
+#
+#  L1  etcd::health           连通性检查          默认 ON
+#  L2  etcd::has_leader       集群 leader 检查    默认 ON
+#  L3  etcd::db_size_pct      DB 容量百分比       默认 ON (80%/90%)
+#  L4  etcd::alarm            NOSPACE/CORRUPT     默认 ON
+#  L5  etcd::backend_commit_* 后端 commit 延迟    需配置
+#      etcd::wal_fsync_*      WAL fsync 延迟      需配置
+#      etcd::slow_apply       慢 apply 增量       需配置
+#      etcd::leader_changes   leader 切换增量     需配置
+#      etcd::proposals_failed 提案失败增量        需配置
+#
+# =============================================================================
+
+
+# =============================================================================
+#  基础连接
+# =============================================================================
+
+[[instances]]
+targets = [
+#     "https://10.0.0.1:2379",
+#     "https://10.0.0.2:2379",
+#     "https://10.0.0.3:2379",
+]
+
+# 采集周期。etcd 检查很轻量，30s 是合理默认值。
+interval = "30s"
+
+# 单次 HTTP 请求超时。
+timeout = "5s"
+
+# 并发检查数。3 节点集群用默认 5 即可，10+ 节点可调高。
+concurrency = 5
+
+# --- TLS ---
+# targets 使用 https:// 时必须配置。注意要用 client 证书，不是 server 证书。
+# 确认方法：echo $ETCDCTL_CACERT / $ETCDCTL_CERT / $ETCDCTL_KEY
+#
+# tls_ca   = "/etc/etcd/pki/ca.pem"
+# tls_cert = "/etc/etcd/pki/client.pem"
+# tls_key  = "/etc/etcd/pki/client-key.pem"
+# insecure_skip_verify = false
+
+
+# =============================================================================
+#  L1: 连通性 — etcd::health
+# =============================================================================
+# GET /health，检查返回 {"health":"true"}。始终开启，连不上必须告警。
+#
+# connectivity_severity — 连接失败时的告警级别
+#   可选值：Critical | Warning，默认 Critical
+#
+# health_path = "/health"
+# connectivity_severity = "Critical"
+
+
+# =============================================================================
+#  L2: 集群角色 — etcd::has_leader
+# =============================================================================
+# 检查集群是否有 leader。无 leader = 无法写入 = 硬故障。
+#
+# disabled — 是否关闭此检查，默认 false（生产环境不建议关闭）
+# severity — 告警级别，可选值：Critical | Warning，默认 Critical
+#
+# [instances.has_leader]
+# disabled = false
+# severity = "Critical"
+
+
+# =============================================================================
+#  L3: 容量 — etcd::db_size_pct
+# =============================================================================
+# DB 大小占 quota 的百分比。超过 quota 会触发 NOSPACE 并拒绝所有写入。
+#
+# disabled — 是否关闭此检查，默认 false
+#
+# quota_backend_bytes — etcd 的 --quota-backend-bytes 值
+#   默认 0 = 自动从 /metrics 的 etcd_server_quota_backend_bytes 获取（推荐）
+#   自动获取失败时回退到 etcd 默认值 2GB
+#   支持人类可读格式："2GB"、"8GB"、"512MB"，也支持纯数字（按字节算）
+#   查看实际值：cat /proc/$(pgrep etcd)/cmdline | tr '\0' '\n' | grep quota
+#
+# warn_ge     — Warning 百分比阈值，默认 80（有时间做 compaction/defrag）
+# critical_ge — Critical 百分比阈值，默认 90（再不处理就触发 NOSPACE）
+#
+# [instances.db_size_pct]
+# disabled = false
+# quota_backend_bytes = 0       # 0 = 自动检测
+# warn_ge    = 80
+# critical_ge = 90
+
+
+# =============================================================================
+#  L4: etcd 自身告警 — etcd::alarm
+# =============================================================================
+# 检查 etcd 是否有活跃的 NOSPACE / CORRUPT 告警，出现意味着已发生硬故障。
+#
+# disabled — 是否关闭此检查，默认 false
+# severity — 告警级别，可选值：Critical | Warning，默认 Critical
+#
+# [instances.alarm]
+# disabled = false
+# severity = "Critical"
+
+
+# =============================================================================
+#  L5a: 后端 commit 延迟 — etcd::backend_commit_p*
+# =============================================================================
+# etcd 每次写操作都要调用 boltdb backend commit 落盘。这个延迟变慢时，
+# 客户端写请求会超时，K8s API Server 变慢，严重时触发 leader 切换。
+# 典型根因：磁盘 I/O 瓶颈、DB 过大未 compaction、内存不足导致 mmap 换页。
+#
+# phi — 分位数，取值范围 (0, 1)
+#   常用值：0.50 (P50中位数)、0.90 (P90)、0.95 (P95)、0.99 (P99)、0.999 (P999)
+#   phi = 0.99 产生事件 etcd::backend_commit_p99
+#
+# warn_ge     — Warning 阈值，支持时间格式："10ms"、"100ms"、"1s" 等
+# critical_ge — Critical 阈值，必须大于 warn_ge
+# disabled    — 设为 true 可跳过此条检查
+#
+# 阈值参考（SSD）：P99 正常 < 25ms，Warning 100ms，Critical 250ms
+# HDD 放宽到 200ms / 500ms。
+
+[[instances.quantile_checks]]
+phi = 0.99
+warn_ge = "100ms"
+critical_ge = "250ms"
+
+# [[instances.quantile_checks]]
+# phi = 0.50
+# warn_ge = "50ms"
+# critical_ge = "100ms"
+
+
+# =============================================================================
+#  L5b: WAL fsync 延迟 — etcd::wal_fsync_p*
+# =============================================================================
+# WAL 是写入的第一道防线，fsync 将日志从内核缓存刷到磁盘。
+# WAL fsync 和 backend commit 通常一起变差（共享磁盘），但如果只有 WAL 慢，
+# 说明 WAL 目录所在的磁盘有单独问题（etcd 支持 WAL 和数据分盘部署）。
+# 生产环境建议和 backend commit 同时监控，便于定位瓶颈在 WAL 还是 boltdb。
+#
+# 参数与 quantile_checks 完全一致（phi / warn_ge / critical_ge / disabled）。
+
+# [[instances.wal_fsync_checks]]
+# phi = 0.99
+# warn_ge = "100ms"
+# critical_ge = "250ms"
+
+
+# =============================================================================
+#  L5c: 增量计数器 — slow_apply / leader_changes / proposals_failed
+# =============================================================================
+# 以下指标是累计计数器，catpaw 自动算每个采集周期的增量（delta）。
+# 首次采集建立基线不告警，etcd 重启导致计数器回退按 delta=0 处理。
+#
+# warn_ge     — 周期增量（整数） >= 此值触发 Warning
+# critical_ge — 周期增量（整数） >= 此值触发 Critical，必须大于 warn_ge
+#
+#
+# --- slow_apply ---
+# raft 提案 apply 耗时超过 100ms 的次数。偶尔 1-2 次可能是 I/O 抖动，
+# 持续出现说明磁盘或 CPU 跟不上。与 backend_commit 的关系：
+# commit 慢导致 apply 慢是最常见路径，但 commit 正常而 apply 慢指向 CPU 瓶颈。
+#
+# [instances.slow_apply]
+# warn_ge = 1
+# critical_ge = 5
+#
+#
+# --- leader_changes ---
+# leader 选举次数。每次切换意味着 1-3 秒写入不可用，watch 连接断开重连。
+# 典型根因：网络抖动、磁盘太慢（心跳超时内完不成 fsync）、节点重启。
+#
+# [instances.leader_changes]
+# warn_ge = 1
+# critical_ge = 3
+#
+#
+# --- proposals_failed ---
+# 提案无法达成多数派共识。这是最严重的信号：多数节点不可用或网络分区。
+# 与 leader_changes 的区别：leader_changes 说明还能选出 leader，
+# proposals_failed 说明连共识都达不成。
+#
+# [instances.proposals_failed]
+# warn_ge = 1
+# critical_ge = 5
+
+
+# =============================================================================
+#  告警策略
+# =============================================================================
+# for_duration    — 持续异常多少秒才触发告警（防抖），偶发毛刺不告警
+# repeat_interval — 未恢复时重复通知间隔
+# repeat_number   — 最多重复通知几次，之后不再重复
+
+[instances.alerting]
+for_duration = 10
+repeat_interval = "5m"
+repeat_number = 3
+
+
+# =============================================================================
+#  AI 自动诊断
+# =============================================================================
+# 告警触发后自动调用 AI + 诊断工具进行根因分析，结果回填告警平台。
+#
+# enabled      — 是否开启
+# min_severity — 最低触发级别，"Warning" 表示 Warning 和 Critical 都会触发
+# timeout      — AI 诊断超时，默认 120s
+# cooldown     — 同一 target 的诊断冷却期，防止重复诊断，默认 10m
+
+[instances.diagnose]
+enabled = true
+min_severity = "Warning"
+# timeout = "120s"
+# cooldown = "10m"

--- a/digcore/diagnose/engine.go
+++ b/digcore/diagnose/engine.go
@@ -153,6 +153,12 @@ func (e *DiagnoseEngine) RunDiagnose(req *DiagnoseRequest) *DiagnoseRecord {
 
 	if report != "" && len(req.Events) > 0 {
 		e.forwardReport(req, session.Record, report)
+	} else if report == "" {
+		logger.Logger.Warnw("diagnose report empty, skipping forward",
+			"plugin", req.Plugin, "target", req.Target, "status", session.Record.Status)
+	} else if len(req.Events) == 0 {
+		logger.Logger.Warnw("diagnose has no events, skipping forward",
+			"plugin", req.Plugin, "target", req.Target, "report_len", len(report))
 	}
 
 	e.state.AddTokens(session.Record.AI.InputTokens, session.Record.AI.OutputTokens)
@@ -465,12 +471,20 @@ func (e *DiagnoseEngine) forwardReport(req *DiagnoseRequest, record *DiagnoseRec
 	comment := FormatReportComment(record, report, e.cfg.Language)
 	now := time.Now().Unix()
 
+	logger.Logger.Infow("diagnose forwarding report",
+		"plugin", req.Plugin, "target", req.Target,
+		"event_count", len(req.Events), "report_len", len(report), "comment_len", len(comment))
+
 	seen := make(map[string]bool, len(req.Events))
 	for _, original := range req.Events {
 		if seen[original.AlertKey] {
 			continue
 		}
 		seen[original.AlertKey] = true
+
+		logger.Logger.Infow("diagnose forwarding comment to notifiers",
+			"alert_key", original.AlertKey, "plugin", req.Plugin, "target", req.Target)
+
 		if notify.ForwardComment(original.AlertKey, comment) {
 			logger.Logger.Infow("diagnose report commented",
 				"alert_key", original.AlertKey, "plugin", req.Plugin, "target", req.Target, "ts", now)

--- a/digcore/diagnose/report_test.go
+++ b/digcore/diagnose/report_test.go
@@ -109,7 +109,7 @@ func TestFormatReport_ShortBody(t *testing.T) {
 
 func TestFormatReportComment_Truncation(t *testing.T) {
 	record := newTestRecord()
-	longBody := strings.Repeat("诊断结论", 300)
+	longBody := strings.Repeat("诊断结论", 1200)
 	result := FormatReportComment(record, longBody, "zh")
 	if got := len([]rune(result)); got > maxCommentChars {
 		t.Fatalf("comment should be at most %d chars, got %d", maxCommentChars, got)

--- a/digcore/notify/flashduty.go
+++ b/digcore/notify/flashduty.go
@@ -72,6 +72,9 @@ func (f *FlashdutyNotifier) Comment(alertKey, comment string) bool {
 		return false
 	}
 
+	logger.Logger.Infow("flashduty: sending comment",
+		"alert_key", alertKey, "comment_url", f.commentURL, "comment_len", len(comment))
+
 	bs, err := json.Marshal(flashdutyCommentPayload{
 		AlertKey: alertKey,
 		Comment:  comment,
@@ -91,6 +94,8 @@ func (f *FlashdutyNotifier) Comment(alertKey, comment string) bool {
 
 		ok, retryable := f.doPost(alertKey, f.commentURL, bs)
 		if ok {
+			logger.Logger.Infow("flashduty: comment sent successfully",
+				"alert_key", alertKey)
 			return true
 		}
 		if !retryable {

--- a/plugins/etcd/design.md
+++ b/plugins/etcd/design.md
@@ -1,0 +1,281 @@
+# etcd 插件设计
+
+## 动机
+
+catpaw 的告警与 AI 诊断链路只对引擎内产出的 Event 生效（`engine.mayTriggerDiagnose`）。
+Prometheus 侧的 etcd 告警规则无法触发 catpaw 的诊断闭环。
+
+本插件通过直接拉取 etcd 的 HTTP API 和 Prometheus 指标端点，
+在 catpaw 引擎内产出面向故障语义的 Event，覆盖 5 个信号层次。
+
+## 设计理念
+
+参考 catpaw Redis 插件的设计哲学：
+
+1. **语义监控 > 指标搬运** — 不做 exporter 替代品，把 etcd 语义翻译成故障判断
+2. **两层架构** — 周期检查只做轻量强信号；重操作（metrics 深度分析、集群快照）留到 AI 诊断
+3. **信号分层** — 按故障层次组织，默认只盯"硬故障"
+4. **默认保守** — 与拓扑设计强相关的检查默认关闭
+5. **delta 而非累计值** — 累计计数器用采集周期增量做阈值判断
+
+## 部署架构
+
+### 集中监控（推荐）
+
+一个 catpaw 实例即可监控整个 etcd 集群，将所有成员地址填入 `targets`。
+
+```
+                     ┌─────────────────┐
+                     │  catpaw (单点)   │
+                     │  targets = [    │
+                     │   node1:2379,   │
+                     │   node2:2379,   │
+                     │   node3:2379    │
+                     │  ]              │
+                     └───┬───┬───┬─────┘
+                         │   │   │
+              ┌──────────┘   │   └──────────┐
+              ▼              ▼              ▼
+        ┌──────────┐  ┌──────────┐  ┌──────────┐
+        │  etcd-1  │  │  etcd-2  │  │  etcd-3  │
+        └──────────┘  └──────────┘  └──────────┘
+```
+
+- catpaw 并发检查每个 target，事件通过 `target` label 区分来源节点
+- AI 诊断的 `etcd_cluster_status` 工具遍历全部 targets 横向对比
+- 单节点诊断工具自动路由到触发告警的那个 target（非固定 Targets[0]）
+- 不需要在每个 etcd 成员上都安装 catpaw
+
+### 分散监控
+
+每个 etcd 成员上安装 catpaw，`targets` 只填 localhost。
+适用于网络隔离或需要本机系统级诊断的场景，但失去了集群横向对比能力。
+
+## 与 Prometheus 的差异
+
+- 本插件不做通用 exporter，只关注面向故障的信号
+- Prometheus 使用 `rate(metric[interval])` 对计数器求速率后再算分位数；本插件使用 **瞬时累积分布** 直接算分位数
+- 与 Prometheus 告警可能重复，可在 FlashDuty 侧合并
+
+## 信号分层
+
+### Layer 1: 连通性 — "能不能连上"
+
+| check | 默认 | 数据源 | 说明 |
+|-------|------|--------|------|
+| `etcd::health` | ON | GET /health | JSON health=="true" |
+
+### Layer 2: 集群角色 — "集群状态对不对"
+
+| check | 默认 | 数据源 | 说明 |
+|-------|------|--------|------|
+| `etcd::has_leader` | ON (Critical) | POST /v3/maintenance/status | leader != 0 |
+
+集群无 leader = 无法写入 = 硬故障，默认开启。
+
+### Layer 3: 容量边界 — "快撑满了吗"
+
+| check | 默认 | 数据源 | 说明 |
+|-------|------|--------|------|
+| `etcd::db_size_pct` | ON (80/90%) | POST /v3/maintenance/status | dbSize / quota 百分比 |
+
+quota 默认自动检测（从 etcd 的 `/metrics` 中读取 `etcd_server_quota_backend_bytes`）。
+自动检测失败时回退到 etcd 默认值 2GB。也可在配置中手动指定。
+
+### Layer 4: 告警 — "有没有硬故障告警"
+
+| check | 默认 | 数据源 | 说明 |
+|-------|------|--------|------|
+| `etcd::alarm` | ON (Critical) | POST /v3/maintenance/alarm | NOSPACE / CORRUPT 告警检测 |
+
+### Layer 5: 性能 — "磁盘 I/O 是否异常"
+
+| check | 默认 | 数据源 | 说明 |
+|-------|------|--------|------|
+| `etcd::backend_commit_p*` | 需配置 | GET /metrics (histogram) | 后端 commit 直方图分位数 |
+| `etcd::wal_fsync_p*` | 需配置 | GET /metrics (histogram) | WAL fsync 直方图分位数 |
+| `etcd::slow_apply` | 需配置 | GET /metrics (counter) | slow apply delta (周期增量) |
+| `etcd::leader_changes` | 需配置 | GET /metrics (counter) | leader election delta |
+| `etcd::proposals_failed` | 需配置 | GET /metrics (counter) | proposal 失败 delta |
+
+## 配置说明
+
+### 基础配置
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `targets` | `[]string` | — | etcd endpoint URL（http:// 或 https://） |
+| `interval` | `Duration` | `30s` | 采集周期 |
+| `timeout` | `Duration` | `5s` | HTTP 请求超时 |
+| `concurrency` | `int` | `5` | 并发检查数 |
+| `tls_ca` | `string` | — | CA 证书路径 |
+| `tls_cert` | `string` | — | 客户端证书路径（注意用 client.pem，不是 server.pem） |
+| `tls_key` | `string` | — | 客户端私钥路径 |
+| `insecure_skip_verify` | `bool` | `false` | 跳过服务端证书验证（不推荐） |
+| `health_path` | `string` | `/health` | 健康检查端点 |
+| `metrics_path` | `string` | `/metrics` | 指标端点 |
+| `connectivity_severity` | `string` | `Critical` | 连通性失败告警级别 |
+
+### has_leader
+
+| 字段 | 默认 | 说明 |
+|------|------|------|
+| `disabled` | `false` | 禁用此检查 |
+| `severity` | `Critical` | 无 leader 时的告警级别 |
+
+### db_size_pct
+
+| 字段 | 默认 | 说明 |
+|------|------|------|
+| `disabled` | `false` | 禁用此检查 |
+| `quota_backend_bytes` | `0` (自动检测) | etcd 的 quota 值，0=从 metrics 自动获取 |
+| `warn_ge` | `80` | Warning 百分比阈值 |
+| `critical_ge` | `90` | Critical 百分比阈值 |
+
+### alarm
+
+| 字段 | 默认 | 说明 |
+|------|------|------|
+| `disabled` | `false` | 禁用此检查 |
+| `severity` | `Critical` | 有 alarm 时的告警级别 |
+
+### quantile_checks / wal_fsync_checks
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `phi` | `float64` | 分位数（0.90/0.95/0.99） |
+| `warn_ge` | `Duration` | Warning 阈值 |
+| `critical_ge` | `Duration` | Critical 阈值 |
+| `disabled` | `bool` | 跳过此项 |
+
+`histogram_metric` 默认 `etcd_disk_backend_commit_duration_seconds`；
+`wal_fsync_metric` 默认 `etcd_disk_wal_fsync_duration_seconds`。
+
+### slow_apply / leader_changes / proposals_failed
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `warn_ge` | `int` | 周期增量 >= 此值触发 Warning |
+| `critical_ge` | `int` | 周期增量 >= 此值触发 Critical |
+
+Delta 机制：首次采集建立基线（产出 Ok 事件），后续每周期计算 `当前值 - 上次值`。
+计数器回退（如 etcd 重启）按 delta=0 处理，不产生误报。
+
+### alerting
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `for_duration` | `int` | 持续异常多少秒后才告警（防抖） |
+| `repeat_interval` | `Duration` | 未恢复时重复通知间隔 |
+| `repeat_number` | `int` | 最多重复通知次数 |
+
+### diagnose
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `enabled` | `bool` | 是否开启 AI 诊断 |
+| `min_severity` | `string` | 触发诊断的最低告警级别 |
+| `timeout` | `Duration` | AI 诊断超时（默认 120s） |
+| `cooldown` | `Duration` | 同 target 诊断冷却期（默认 10m） |
+
+## 最小落地方案
+
+### 场景 1：单机 etcd（非 TLS）
+
+```toml
+[[instances]]
+targets = ["http://127.0.0.1:2379"]
+```
+
+一行配置，4 项默认检查自动生效：health + has_leader + db_size_pct + alarm。
+
+### 场景 2：3 节点集群（mTLS）
+
+```toml
+[[instances]]
+targets = [
+    "https://10.0.0.1:2379",
+    "https://10.0.0.2:2379",
+    "https://10.0.0.3:2379",
+]
+tls_ca   = "/opt/etcd/pki/ca.pem"
+tls_cert = "/opt/etcd/pki/client.pem"
+tls_key  = "/opt/etcd/pki/client-key.pem"
+
+[[instances.quantile_checks]]
+phi = 0.99
+warn_ge = "100ms"
+critical_ge = "250ms"
+```
+
+在默认 4 项检查基础上，加 backend commit P99 延迟检查。
+
+### 场景 3：大 quota 集群 + 全量监控
+
+```toml
+[[instances]]
+targets = ["https://10.0.0.1:2379"]
+tls_ca   = "/opt/etcd/pki/ca.pem"
+tls_cert = "/opt/etcd/pki/client.pem"
+tls_key  = "/opt/etcd/pki/client-key.pem"
+
+[instances.db_size_pct]
+quota_backend_bytes = "8GB"
+
+[[instances.quantile_checks]]
+phi = 0.99
+warn_ge = "100ms"
+critical_ge = "250ms"
+
+[[instances.wal_fsync_checks]]
+phi = 0.99
+warn_ge = "100ms"
+critical_ge = "250ms"
+
+[instances.slow_apply]
+warn_ge = 1
+critical_ge = 5
+
+[instances.leader_changes]
+warn_ge = 3
+critical_ge = 5
+```
+
+## AI 诊断工具（8 个）
+
+| 工具 | 方法 | 范围 | 诊断场景 |
+|------|------|------|----------|
+| `etcd_health` | GET /health | 告警节点 | 基础健康判断 |
+| `etcd_version` | GET /version | 告警节点 | 版本信息/兼容性排查 |
+| `etcd_endpoint_status` | POST /v3/maintenance/status | 告警节点 | leader/raft/dbSize |
+| `etcd_cluster_status` | 遍历所有 targets 调用 status | **全集群** | 横向对比 dbSize/碎片率/leader/raftIndex |
+| `etcd_commit_summary` | GET /metrics → 结构化解析 | 告警节点 | commit/wal 分位数、DB 大小、slow apply、自动提示 |
+| `etcd_alarm_list` | POST /v3/maintenance/alarm | 告警节点 | NOSPACE/CORRUPT 告警（etcd alarm 是集群级别） |
+| `etcd_member_list` | POST /v3/cluster/member/list | 集群 | 成员拓扑/离线检测 |
+| `etcd_metrics_relevant` | GET /metrics（过滤） | 告警节点 | 原始指标深入分析 |
+
+**目标精准路由**：`getEtcdAccessor()` 自动将 `baseURL` 切换到 `session.Record.Alert.Target`
+（触发告警的节点），单节点工具查的是出问题的那个节点而非固定 Targets[0]。
+
+### AI 系统级辅助工具
+
+AI 在诊断时还会结合 catpaw 的通用 shell 工具，category description 中给出了提示：
+
+- **进程检查**：`ps aux|grep etcd`、`ss -tlnp|grep 2379`、`netstat -tlnp|grep etcd`
+- **启动参数**：`cat /proc/$(pgrep etcd)/cmdline|tr '\0' '\n'`
+- **磁盘 I/O**：`iostat -xd 1 3`、`df -h <data-dir>`
+- **系统资源**：`top -bn1|head -20`、`free -h`
+- **日志**：`journalctl -u etcd` 或从进程 cmdline 找日志路径
+
+### commit 慢排查路径与工具映射
+
+```
+1. 单节点 or 全集群？      → etcd_cluster_status（横向对比）
+2. 磁盘 I/O？              → shell: iostat -xd 1 3
+3. DB 膨胀 / 碎片化？      → etcd_commit_summary（自动计算碎片率 + 告警提示）
+4. NOSPACE / CORRUPT？      → etcd_alarm_list
+5. 系统资源？              → shell: top / free / vmstat
+6. etcd 内部（慢 apply/wal）→ etcd_commit_summary + etcd_metrics_relevant
+7. 进程参数 / 数据目录？    → shell: cat /proc/$(pgrep etcd)/cmdline
+8. etcd 日志？             → shell: journalctl / log file
+```

--- a/plugins/etcd/diagnose.go
+++ b/plugins/etcd/diagnose.go
@@ -1,0 +1,640 @@
+package etcd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cprobe/catpaw/digcore/diagnose"
+	"github.com/cprobe/catpaw/digcore/plugins"
+)
+
+const (
+	maxDiagBodySize  = 1 << 20  // 1MB
+	maxRelevantLines = 500
+	maxRelevantBytes = 64 << 10 // 64KB
+)
+
+var _ plugins.Diagnosable = (*EtcdPlugin)(nil)
+
+// EtcdAccessor provides HTTP access to etcd members for diagnostic tools.
+type EtcdAccessor struct {
+	baseURL    string   // primary target (alert member)
+	allTargets []string // all configured targets for cluster-wide tools
+	client     *http.Client
+}
+
+func (a *EtcdAccessor) get(ctx context.Context, path string, maxBytes int64) ([]byte, error) {
+	return a.getURL(ctx, a.baseURL+path, maxBytes)
+}
+
+func (a *EtcdAccessor) getURL(ctx context.Context, url string, maxBytes int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	return body, nil
+}
+
+// postJSON sends a POST with JSON body to the etcd gRPC gateway and returns the response.
+func (a *EtcdAccessor) postJSON(ctx context.Context, path string, payload any, maxBytes int64) ([]byte, error) {
+	return a.postJSONURL(ctx, a.baseURL+path, payload, maxBytes)
+}
+
+func (a *EtcdAccessor) postJSONURL(ctx context.Context, url string, payload any, maxBytes int64) ([]byte, error) {
+	var bodyReader io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	} else {
+		bodyReader = bytes.NewReader([]byte("{}"))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	return body, nil
+}
+
+// Close is a no-op; the HTTP client uses DisableKeepAlives.
+func (a *EtcdAccessor) Close() error { return nil }
+
+func (p *EtcdPlugin) RegisterDiagnoseTools(registry *diagnose.ToolRegistry) {
+	registry.RegisterCategory("etcd", "etcd",
+		"etcd diagnostic tools: health, cluster-wide status comparison, commit latency summary, alarms, member list, filtered metrics. "+
+			"Tip: combine with system shell tools for deeper investigation: "+
+			"process check (ps aux|grep etcd, ss -tlnp|grep 2379, netstat -tlnp|grep etcd), "+
+			"startup flags (cat /proc/$(pgrep etcd)/cmdline|tr '\\0' '\\n' — shows --data-dir, --quota-backend-bytes, --auto-compaction-*), "+
+			"disk I/O (iostat -xd 1 3, df -h <data-dir>), "+
+			"system resources (top -bn1|head -20, free -h), "+
+			"etcd logs (journalctl -u etcd --no-pager -n 100, or check log file path from process cmdline).",
+		diagnose.ToolScopeRemote)
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name:        "etcd_health",
+		Description: "GET /health from the alert member, returns JSON body with health status",
+		Scope:       diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			body, err := acc.get(ctx, "/health", maxDiagBodySize)
+			if err != nil {
+				return "", fmt.Errorf("etcd_health: %w", err)
+			}
+			return string(body), nil
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name:        "etcd_version",
+		Description: "GET /version from the alert member, returns etcd server and cluster version",
+		Scope:       diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			body, err := acc.get(ctx, "/version", maxDiagBodySize)
+			if err != nil {
+				return "", fmt.Errorf("etcd_version: %w", err)
+			}
+			return string(body), nil
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name:        "etcd_endpoint_status",
+		Description: "POST /v3/maintenance/status on the alert member. Returns leader ID, raft index/term, DB size. For cluster-wide comparison use etcd_cluster_status instead.",
+		Scope:       diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			body, err := acc.postJSON(ctx, "/v3/maintenance/status", nil, maxDiagBodySize)
+			if err != nil {
+				return "", fmt.Errorf("etcd_endpoint_status: %w", err)
+			}
+			return prettyJSON(body), nil
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name: "etcd_cluster_status",
+		Description: "Query /v3/maintenance/status on ALL configured etcd members and output a comparison table: " +
+			"endpoint, leader, dbSize, dbSizeInUse, fragmentation ratio, raftIndex, raftTerm. " +
+			"Key for determining if slow commit is single-node or cluster-wide, and identifying DB bloat or fragmentation.",
+		Scope: diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			return acc.clusterStatus(ctx), nil
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name: "etcd_commit_summary",
+		Description: "Fetch /metrics from the alert member, parse and return a structured summary of commit-latency-related indicators: " +
+			"backend_commit P50/P90/P99, wal_fsync P50/P90/P99, DB size, slow apply/read counts, compaction duration. " +
+			"Much more token-efficient than etcd_metrics_relevant for commit-slow diagnosis.",
+		Scope: diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			return acc.commitSummary(ctx)
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name:        "etcd_alarm_list",
+		Description: "List active alarms (NOSPACE, CORRUPT) from the alert member. Empty alarms array means no active alarms.",
+		Scope:       diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			payload := map[string]interface{}{"action": 0, "memberID": 0}
+			body, err := acc.postJSON(ctx, "/v3/maintenance/alarm", payload, maxDiagBodySize)
+			if err != nil {
+				return "", fmt.Errorf("etcd_alarm_list: %w", err)
+			}
+			return prettyJSON(body), nil
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name:        "etcd_member_list",
+		Description: "List cluster membership: member IDs, names, peer/client URLs, learner status. Key for diagnosing cluster topology and connectivity issues.",
+		Scope:       diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			body, err := acc.postJSON(ctx, "/v3/cluster/member/list", nil, maxDiagBodySize)
+			if err != nil {
+				return "", fmt.Errorf("etcd_member_list: %w", err)
+			}
+			return prettyJSON(body), nil
+		},
+	})
+
+	registry.Register("etcd", diagnose.DiagnoseTool{
+		Name:        "etcd_metrics_relevant",
+		Description: "GET /metrics filtered to disk/server/mvcc/network/slow lines (max 500 lines / 64KB). Use for deep-dive when etcd_commit_summary is insufficient.",
+		Scope:       diagnose.ToolScopeRemote,
+		RemoteExecute: func(ctx context.Context, session *diagnose.DiagnoseSession, args map[string]string) (string, error) {
+			acc, err := getEtcdAccessor(session)
+			if err != nil {
+				return "", err
+			}
+			body, err := acc.get(ctx, "/metrics", maxDiagBodySize)
+			if err != nil {
+				return "", fmt.Errorf("etcd_metrics_relevant: %w", err)
+			}
+			return filterRelevantMetrics(strings.NewReader(string(body))), nil
+		},
+	})
+
+	registry.RegisterAccessorFactory("etcd", func(ctx context.Context, instanceRef any, target string) (any, error) {
+		ins, ok := instanceRef.(*Instance)
+		if !ok {
+			return nil, fmt.Errorf("etcd accessor factory: expected *Instance, got %T", instanceRef)
+		}
+		if ins.client == nil {
+			return nil, fmt.Errorf("etcd accessor factory: http client not initialized")
+		}
+		baseURL := ""
+		if len(ins.Targets) > 0 {
+			baseURL = ins.Targets[0]
+		}
+		return &EtcdAccessor{
+			baseURL:    baseURL,
+			allTargets: ins.Targets,
+			client:     ins.client,
+		}, nil
+	})
+}
+
+// clusterStatus queries /v3/maintenance/status on every configured target
+// and formats a comparison table.
+func (a *EtcdAccessor) clusterStatus(ctx context.Context) string {
+	if len(a.allTargets) == 0 {
+		return "(no targets configured)"
+	}
+
+	type memberStatus struct {
+		endpoint string
+		raw      map[string]interface{}
+		err      error
+	}
+
+	results := make([]memberStatus, len(a.allTargets))
+	for i, target := range a.allTargets {
+		results[i].endpoint = target
+		body, err := a.postJSONURL(ctx, target+"/v3/maintenance/status", nil, maxDiagBodySize)
+		if err != nil {
+			results[i].err = err
+			continue
+		}
+		var parsed map[string]interface{}
+		if jsonErr := json.Unmarshal(body, &parsed); jsonErr != nil {
+			results[i].err = jsonErr
+			continue
+		}
+		results[i].raw = parsed
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-40s %-10s %-14s %-14s %-8s %-14s %-10s %s\n",
+		"ENDPOINT", "IS_LEADER", "DB_SIZE", "DB_IN_USE", "FRAG%", "RAFT_INDEX", "RAFT_TERM", "ERROR")
+	b.WriteString(strings.Repeat("-", 120))
+	b.WriteByte('\n')
+
+	for _, r := range results {
+		if r.err != nil {
+			fmt.Fprintf(&b, "%-40s %-10s %-14s %-14s %-8s %-14s %-10s %s\n",
+				r.endpoint, "-", "-", "-", "-", "-", "-", r.err.Error())
+			continue
+		}
+
+		leader := jsonStr(r.raw, "leader")
+		memberID := jsonStr(r.raw, "header", "member_id")
+		isLeader := "no"
+		if leader != "" && leader == memberID {
+			isLeader = "YES"
+		}
+
+		dbSize := jsonFloat(r.raw, "dbSize")
+		dbInUse := jsonFloat(r.raw, "dbSizeInUse")
+		frag := ""
+		if dbSize > 0 && dbInUse > 0 {
+			fragPct := (1.0 - dbInUse/dbSize) * 100
+			frag = fmt.Sprintf("%.1f%%", fragPct)
+		}
+
+		fmt.Fprintf(&b, "%-40s %-10s %-14s %-14s %-8s %-14s %-10s %s\n",
+			r.endpoint,
+			isLeader,
+			humanBytes(dbSize),
+			humanBytes(dbInUse),
+			frag,
+			jsonStr(r.raw, "raftIndex"),
+			jsonStr(r.raw, "raftTerm"),
+			"")
+	}
+
+	return b.String()
+}
+
+// commitSummary fetches /metrics and returns a structured summary of
+// commit-latency-related indicators.
+func (a *EtcdAccessor) commitSummary(ctx context.Context) (string, error) {
+	body, err := a.get(ctx, "/metrics", maxDiagBodySize)
+	if err != nil {
+		return "", fmt.Errorf("fetch /metrics: %w", err)
+	}
+	reader := strings.NewReader(string(body))
+
+	// We need to scan the full body multiple times for different metrics.
+	// Parse all needed values in a single pass.
+	lines := strings.Split(string(body), "\n")
+
+	var b strings.Builder
+	b.WriteString("=== etcd Commit Latency Summary ===\n\n")
+
+	// 1. Backend commit histogram
+	reader.Reset(string(body))
+	if commitH, parseErr := parseHistogram(reader, "etcd_disk_backend_commit_duration_seconds", maxDiagBodySize); parseErr == nil {
+		b.WriteString("[backend_commit latency]\n")
+		writeQuantiles(&b, commitH, []float64{0.50, 0.90, 0.95, 0.99})
+		if commitH.Count > 0 {
+			avg := time.Duration(commitH.Sum / commitH.Count * float64(time.Second))
+			fmt.Fprintf(&b, "  avg:     %s\n", formatDiagLatency(avg))
+			fmt.Fprintf(&b, "  count:   %.0f\n", commitH.Count)
+		}
+		b.WriteByte('\n')
+	} else {
+		fmt.Fprintf(&b, "[backend_commit latency] not available: %v\n\n", parseErr)
+	}
+
+	// 2. WAL fsync histogram
+	reader.Reset(string(body))
+	if walH, parseErr := parseHistogram(reader, "etcd_disk_wal_fsync_duration_seconds", maxDiagBodySize); parseErr == nil {
+		b.WriteString("[wal_fsync latency]\n")
+		writeQuantiles(&b, walH, []float64{0.50, 0.90, 0.95, 0.99})
+		if walH.Count > 0 {
+			avg := time.Duration(walH.Sum / walH.Count * float64(time.Second))
+			fmt.Fprintf(&b, "  avg:     %s\n", formatDiagLatency(avg))
+			fmt.Fprintf(&b, "  count:   %.0f\n", walH.Count)
+		}
+		b.WriteByte('\n')
+	} else {
+		fmt.Fprintf(&b, "[wal_fsync latency] not available: %v\n\n", parseErr)
+	}
+
+	// 3. Key gauges and counters (single-pass extraction)
+	gauges := map[string]float64{}
+	wantGauges := map[string]bool{
+		"etcd_mvcc_db_total_size_in_bytes":        true,
+		"etcd_mvcc_db_total_size_in_use_in_bytes": true,
+		"etcd_server_slow_apply_total":             true,
+		"etcd_server_slow_read_indexes_total":      true,
+		"etcd_server_proposals_failed_total":        true,
+		"etcd_server_proposals_pending":             true,
+		"etcd_server_leader_changes_seen_total":     true,
+	}
+
+	for _, line := range lines {
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		for name := range wantGauges {
+			if strings.HasPrefix(line, name+" ") || strings.HasPrefix(line, name+"{") {
+				gauges[name] = parseMetricValue(line)
+				break
+			}
+		}
+	}
+
+	b.WriteString("[storage]\n")
+	if v, ok := gauges["etcd_mvcc_db_total_size_in_bytes"]; ok {
+		fmt.Fprintf(&b, "  db_size:       %s\n", humanBytes(v))
+	}
+	if v, ok := gauges["etcd_mvcc_db_total_size_in_use_in_bytes"]; ok {
+		fmt.Fprintf(&b, "  db_in_use:     %s\n", humanBytes(v))
+	}
+	if total, ok1 := gauges["etcd_mvcc_db_total_size_in_bytes"]; ok1 {
+		if inUse, ok2 := gauges["etcd_mvcc_db_total_size_in_use_in_bytes"]; ok2 && total > 0 {
+			fmt.Fprintf(&b, "  fragmentation: %.1f%%\n", (1.0-inUse/total)*100)
+		}
+	}
+	b.WriteByte('\n')
+
+	b.WriteString("[cluster indicators]\n")
+	writeGauge(&b, gauges, "etcd_server_slow_apply_total", "slow_apply")
+	writeGauge(&b, gauges, "etcd_server_slow_read_indexes_total", "slow_read_indexes")
+	writeGauge(&b, gauges, "etcd_server_proposals_failed_total", "proposals_failed")
+	writeGauge(&b, gauges, "etcd_server_proposals_pending", "proposals_pending")
+	writeGauge(&b, gauges, "etcd_server_leader_changes_seen_total", "leader_changes")
+	b.WriteByte('\n')
+
+	b.WriteString("[diagnosis hints]\n")
+	writeCommitHints(&b, gauges, body)
+
+	return b.String(), nil
+}
+
+func writeQuantiles(b *strings.Builder, h *histogram, phis []float64) {
+	for _, phi := range phis {
+		val, err := histogramQuantile(phi, h)
+		if err != nil || math.IsNaN(val) {
+			fmt.Fprintf(b, "  p%-6s  N/A\n", quantileCheckLabel(phi)[1:])
+			continue
+		}
+		latency := time.Duration(val * float64(time.Second))
+		fmt.Fprintf(b, "  p%-6s  %s\n", quantileCheckLabel(phi)[1:], formatDiagLatency(latency))
+	}
+}
+
+func writeGauge(b *strings.Builder, gauges map[string]float64, metric, label string) {
+	if v, ok := gauges[metric]; ok {
+		fmt.Fprintf(b, "  %-20s %.0f\n", label+":", v)
+	}
+}
+
+func writeCommitHints(b *strings.Builder, gauges map[string]float64, body []byte) {
+	hints := 0
+	if v, ok := gauges["etcd_mvcc_db_total_size_in_bytes"]; ok && v > 2*1024*1024*1024 {
+		fmt.Fprintf(b, "  - DB size > 2GB (%.1f GB): large DB increases commit latency, consider compaction + defrag\n", v/1024/1024/1024)
+		hints++
+	}
+	if total, ok1 := gauges["etcd_mvcc_db_total_size_in_bytes"]; ok1 {
+		if inUse, ok2 := gauges["etcd_mvcc_db_total_size_in_use_in_bytes"]; ok2 && total > 0 {
+			fragPct := (1.0 - inUse/total) * 100
+			if fragPct > 50 {
+				fmt.Fprintf(b, "  - Fragmentation %.1f%%: defrag recommended (db_size=%.1fMB, in_use=%.1fMB)\n",
+					fragPct, total/1024/1024, inUse/1024/1024)
+				hints++
+			}
+		}
+	}
+	if v, ok := gauges["etcd_server_slow_apply_total"]; ok && v > 0 {
+		fmt.Fprintf(b, "  - %.0f slow apply events detected: indicates raft proposal apply latency\n", v)
+		hints++
+	}
+	if v, ok := gauges["etcd_server_leader_changes_seen_total"]; ok && v > 5 {
+		fmt.Fprintf(b, "  - %.0f leader changes: frequent leader election suggests network/disk instability\n", v)
+		hints++
+	}
+	if hints == 0 {
+		b.WriteString("  (no obvious anomalies from metrics alone; check disk I/O via system tools)\n")
+	}
+	b.WriteString("  - Use shell to check: cat /proc/$(pgrep etcd)/cmdline | tr '\\0' ' ' for etcd startup flags\n")
+	b.WriteString("  - Use disk I/O tools to check the device hosting etcd --data-dir\n")
+}
+
+func formatDiagLatency(d time.Duration) string {
+	if d < time.Millisecond {
+		return fmt.Sprintf("%.1f µs", float64(d)/float64(time.Microsecond))
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.2f ms", float64(d)/float64(time.Millisecond))
+	}
+	return fmt.Sprintf("%.3f s", d.Seconds())
+}
+
+func prettyJSON(raw []byte) string {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}
+
+// jsonStr extracts a string from a nested JSON map by key path.
+func jsonStr(m map[string]interface{}, keys ...string) string {
+	cur := m
+	for i, k := range keys {
+		v, ok := cur[k]
+		if !ok {
+			return ""
+		}
+		if i == len(keys)-1 {
+			return fmt.Sprintf("%v", v)
+		}
+		next, ok := v.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		cur = next
+	}
+	return ""
+}
+
+func jsonFloat(m map[string]interface{}, key string) float64 {
+	v, ok := m[key]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return n
+	case json.Number:
+		f, _ := n.Float64()
+		return f
+	default:
+		return 0
+	}
+}
+
+func humanBytes(b float64) string {
+	if b <= 0 {
+		return "0 B"
+	}
+	units := []string{"B", "KB", "MB", "GB", "TB"}
+	i := 0
+	for b >= 1024 && i < len(units)-1 {
+		b /= 1024
+		i++
+	}
+	return fmt.Sprintf("%.1f %s", b, units[i])
+}
+
+func getEtcdAccessor(session *diagnose.DiagnoseSession) (*EtcdAccessor, error) {
+	if session.Accessor == nil {
+		return nil, fmt.Errorf("no etcd accessor in session (remote connection not established)")
+	}
+	acc, ok := session.Accessor.(*EtcdAccessor)
+	if !ok {
+		return nil, fmt.Errorf("session accessor is %T, expected *EtcdAccessor", session.Accessor)
+	}
+	// Override baseURL to the actual alert target so single-node tools
+	// query the right member, not just Targets[0].
+	if alertTarget := session.Record.Alert.Target; alertTarget != "" && alertTarget != acc.baseURL {
+		for _, t := range acc.allTargets {
+			if t == alertTarget {
+				acc.baseURL = alertTarget
+				break
+			}
+		}
+	}
+	return acc, nil
+}
+
+var relevantPrefixes = []string{
+	"etcd_disk_",
+	"etcd_server_",
+	"etcd_mvcc_",
+	"etcd_debugging_",
+	"etcd_network_peer_",
+}
+
+var relevantSubstrings = []string{
+	"slow",
+	"leader",
+	"proposal",
+	"snapshot",
+	"wal",
+	"compaction",
+	"apply",
+}
+
+func filterRelevantMetrics(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	var b strings.Builder
+	lines := 0
+
+	for scanner.Scan() {
+		if lines >= maxRelevantLines || b.Len() >= maxRelevantBytes {
+			fmt.Fprintf(&b, "\n... truncated at %d lines / %d bytes", lines, b.Len())
+			break
+		}
+		line := scanner.Text()
+		if isRelevantLine(line) {
+			b.WriteString(line)
+			b.WriteByte('\n')
+			lines++
+		}
+	}
+
+	if b.Len() == 0 {
+		return "(no relevant etcd metrics found)"
+	}
+	return b.String()
+}
+
+func isRelevantLine(line string) bool {
+	if len(line) == 0 {
+		return false
+	}
+	if line[0] == '#' {
+		for _, p := range relevantPrefixes {
+			if strings.Contains(line, p) {
+				return true
+			}
+		}
+		for _, s := range relevantSubstrings {
+			if strings.Contains(line, s) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, p := range relevantPrefixes {
+		if strings.HasPrefix(line, p) {
+			return true
+		}
+	}
+	for _, s := range relevantSubstrings {
+		if strings.Contains(line, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/etcd/etcd.go
+++ b/plugins/etcd/etcd.go
@@ -1,0 +1,936 @@
+package etcd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cprobe/catpaw/digcore/config"
+	"github.com/cprobe/catpaw/digcore/logger"
+	"github.com/cprobe/catpaw/digcore/pkg/safe"
+	"github.com/cprobe/catpaw/digcore/plugins"
+	"github.com/cprobe/catpaw/digcore/types"
+	"github.com/toolkits/pkg/concurrent/semaphore"
+)
+
+const (
+	pluginName      = "etcd"
+	maxMetricsBytes = 8 << 20
+	maxBodyReadSize = 1 << 20
+
+	defaultQuotaBackendBytes = 2 * 1024 * 1024 * 1024 // 2GB — etcd default
+)
+
+// ---------------------------------------------------------------------------
+// Check config types (following Redis plugin conventions)
+// ---------------------------------------------------------------------------
+
+type QuantileCheck struct {
+	Phi        float64         `toml:"phi"`
+	WarnGe     config.Duration `toml:"warn_ge"`
+	CriticalGe config.Duration `toml:"critical_ge"`
+	Disabled   bool            `toml:"disabled"`
+}
+
+type HasLeaderCheck struct {
+	Disabled bool   `toml:"disabled"`
+	Severity string `toml:"severity"`
+}
+
+type AlarmCheck struct {
+	Disabled bool   `toml:"disabled"`
+	Severity string `toml:"severity"`
+}
+
+type DbSizePctCheck struct {
+	Disabled          bool        `toml:"disabled"`
+	QuotaBackendBytes config.Size `toml:"quota_backend_bytes"`
+	WarnGe            float64     `toml:"warn_ge"`
+	CriticalGe        float64     `toml:"critical_ge"`
+}
+
+type DeltaCounterCheck struct {
+	WarnGe     int `toml:"warn_ge"`
+	CriticalGe int `toml:"critical_ge"`
+}
+
+// ---------------------------------------------------------------------------
+// Instance & Plugin
+// ---------------------------------------------------------------------------
+
+type Instance struct {
+	config.InternalConfig
+
+	Targets              []string        `toml:"targets"`
+	Concurrency          int             `toml:"concurrency"`
+	HealthPath           string          `toml:"health_path"`
+	MetricsPath          string          `toml:"metrics_path"`
+	HistogramMetric      string          `toml:"histogram_metric"`
+	ConnectivitySeverity string          `toml:"connectivity_severity"`
+	QuantileChecks       []QuantileCheck `toml:"quantile_checks"`
+
+	// Layer 2: cluster role — default ON
+	HasLeader HasLeaderCheck `toml:"has_leader"`
+
+	// Layer 3: capacity — default ON (80/90, quota=2GB)
+	DbSizePct DbSizePctCheck `toml:"db_size_pct"`
+
+	// Layer 4: alarms — default ON
+	Alarm AlarmCheck `toml:"alarm"`
+
+	// WAL fsync latency — same histogram approach as backend commit
+	WalFsyncMetric string          `toml:"wal_fsync_metric"`
+	WalFsyncChecks []QuantileCheck `toml:"wal_fsync_checks"`
+
+	// Delta counters — configurable, default OFF
+	SlowApply       DeltaCounterCheck `toml:"slow_apply"`
+	LeaderChanges   DeltaCounterCheck `toml:"leader_changes"`
+	ProposalsFailed DeltaCounterCheck `toml:"proposals_failed"`
+
+	config.HTTPConfig
+	client *http.Client
+
+	statsMu     sync.Mutex
+	prevStats   map[string]etcdCounterSnapshot
+	initialized map[string]bool
+
+	cachedQuota map[string]int64
+}
+
+type etcdCounterSnapshot struct {
+	slowApply       uint64
+	leaderChanges   uint64
+	proposalsFailed uint64
+}
+
+type EtcdPlugin struct {
+	config.InternalConfig
+	Instances []*Instance `toml:"instances"`
+}
+
+func init() {
+	plugins.Add(pluginName, func() plugins.Plugin {
+		return &EtcdPlugin{}
+	})
+}
+
+func (p *EtcdPlugin) GetInstances() []plugins.Instance {
+	ret := make([]plugins.Instance, len(p.Instances))
+	for i := range p.Instances {
+		ret[i] = p.Instances[i]
+	}
+	return ret
+}
+
+func (ins *Instance) Init() error {
+	if len(ins.Targets) == 0 {
+		return nil
+	}
+
+	if ins.HealthPath == "" {
+		ins.HealthPath = "/health"
+	}
+	if ins.MetricsPath == "" {
+		ins.MetricsPath = "/metrics"
+	}
+	if ins.HistogramMetric == "" {
+		ins.HistogramMetric = "etcd_disk_backend_commit_duration_seconds"
+	}
+	if ins.WalFsyncMetric == "" {
+		ins.WalFsyncMetric = "etcd_disk_wal_fsync_duration_seconds"
+	}
+	if ins.Concurrency == 0 {
+		ins.Concurrency = 5
+	}
+	if ins.ConnectivitySeverity == "" {
+		ins.ConnectivitySeverity = types.EventStatusCritical
+	}
+
+	// HasLeader defaults: enabled, Critical
+	if ins.HasLeader.Severity == "" {
+		ins.HasLeader.Severity = types.EventStatusCritical
+	}
+
+	// Alarm defaults: enabled, Critical
+	if ins.Alarm.Severity == "" {
+		ins.Alarm.Severity = types.EventStatusCritical
+	}
+
+	// DbSizePct defaults: enabled, warn=80%, critical=90%
+	// QuotaBackendBytes == 0 means auto-detect from etcd_server_quota_backend_bytes metric
+	if ins.DbSizePct.WarnGe == 0 && ins.DbSizePct.CriticalGe == 0 {
+		ins.DbSizePct.WarnGe = 80
+		ins.DbSizePct.CriticalGe = 90
+	}
+
+	for _, target := range ins.Targets {
+		if strings.HasPrefix(target, "https://") && (ins.UseTLS == nil || !*ins.UseTLS) {
+			t := true
+			ins.UseTLS = &t
+		}
+	}
+
+	if err := validateQuantileChecks("quantile_checks", ins.QuantileChecks); err != nil {
+		return err
+	}
+	if err := validateQuantileChecks("wal_fsync_checks", ins.WalFsyncChecks); err != nil {
+		return err
+	}
+	if err := validateDeltaCounterCheck("slow_apply", ins.SlowApply); err != nil {
+		return err
+	}
+	if err := validateDeltaCounterCheck("leader_changes", ins.LeaderChanges); err != nil {
+		return err
+	}
+	if err := validateDeltaCounterCheck("proposals_failed", ins.ProposalsFailed); err != nil {
+		return err
+	}
+	if ins.DbSizePct.WarnGe > 0 && ins.DbSizePct.CriticalGe > 0 && ins.DbSizePct.WarnGe >= ins.DbSizePct.CriticalGe {
+		return fmt.Errorf("db_size_pct.warn_ge(%.1f) must be less than db_size_pct.critical_ge(%.1f)",
+			ins.DbSizePct.WarnGe, ins.DbSizePct.CriticalGe)
+	}
+
+	client, err := ins.createHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create http client: %v", err)
+	}
+	ins.client = client
+
+	if ins.prevStats == nil {
+		ins.prevStats = make(map[string]etcdCounterSnapshot)
+	}
+	if ins.initialized == nil {
+		ins.initialized = make(map[string]bool)
+	}
+	if ins.cachedQuota == nil {
+		ins.cachedQuota = make(map[string]int64)
+	}
+
+	return nil
+}
+
+func validateQuantileChecks(label string, checks []QuantileCheck) error {
+	for i, qc := range checks {
+		if qc.Disabled {
+			continue
+		}
+		if qc.Phi <= 0 || qc.Phi >= 1 {
+			return fmt.Errorf("%s[%d].phi must be in (0,1), got %v", label, i, qc.Phi)
+		}
+		if qc.WarnGe > 0 && qc.CriticalGe > 0 && qc.WarnGe >= qc.CriticalGe {
+			return fmt.Errorf("%s[%d]: warn_ge(%s) must be less than critical_ge(%s)",
+				label, i, time.Duration(qc.WarnGe), time.Duration(qc.CriticalGe))
+		}
+	}
+	return nil
+}
+
+func validateDeltaCounterCheck(name string, check DeltaCounterCheck) error {
+	if check.WarnGe < 0 || check.CriticalGe < 0 {
+		return fmt.Errorf("%s thresholds must be >= 0", name)
+	}
+	if check.WarnGe > 0 && check.CriticalGe > 0 && check.WarnGe >= check.CriticalGe {
+		return fmt.Errorf("%s.warn_ge(%d) must be less than %s.critical_ge(%d)",
+			name, check.WarnGe, name, check.CriticalGe)
+	}
+	return nil
+}
+
+func (ins *Instance) createHTTPClient() (*http.Client, error) {
+	tlsCfg, err := ins.ClientConfig.TLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	trans := &http.Transport{
+		DialContext:       (&net.Dialer{}).DialContext,
+		DisableKeepAlives: true,
+		TLSClientConfig:   tlsCfg,
+	}
+
+	return &http.Client{
+		Transport: trans,
+		Timeout:   time.Duration(ins.GetTimeout()),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Gather — the 4-layer periodic check
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) Gather(q *safe.Queue[*types.Event]) {
+	if len(ins.Targets) == 0 {
+		return
+	}
+
+	wg := new(sync.WaitGroup)
+	se := semaphore.NewSemaphore(ins.Concurrency)
+	for _, target := range ins.Targets {
+		wg.Add(1)
+		go func(target string) {
+			se.Acquire()
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Logger.Errorw("panic in etcd gather goroutine", "target", target, "recover", r)
+					q.PushFront(ins.newEvent("etcd::health", target).
+						SetEventStatus(types.EventStatusCritical).
+						SetDescription(fmt.Sprintf("panic during check: %v", r)))
+				}
+				se.Release()
+				wg.Done()
+			}()
+			ins.gather(q, target)
+		}(target)
+	}
+	wg.Wait()
+}
+
+func (ins *Instance) gather(q *safe.Queue[*types.Event], target string) {
+	// Layer 1: connectivity
+	ins.gatherHealth(q, target)
+
+	// Pre-fetch /metrics once: reused for L3 quota auto-detection and L5 performance checks
+	var metricsBody []byte
+	if ins.needMetricsFetch() {
+		metricsBody = ins.fetchMetricsBody(target)
+	}
+
+	// Layer 2+3: cluster role (has_leader) + capacity (db_size_pct)
+	ins.gatherStatus(q, target, metricsBody)
+
+	// Layer 4: alarms (NOSPACE / CORRUPT)
+	ins.gatherAlarms(q, target)
+
+	// Layer 5: performance — histograms + delta counters (reuse pre-fetched body)
+	ins.processMetrics(q, target, metricsBody)
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: health (connectivity)
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) gatherHealth(q *safe.Queue[*types.Event], target string) {
+	url := target + ins.HealthPath
+
+	healthEvent := ins.newEvent("etcd::health", target)
+
+	resp, err := ins.client.Get(url)
+	if err != nil {
+		healthEvent.SetEventStatus(ins.ConnectivitySeverity)
+		healthEvent.SetDescription(fmt.Sprintf("GET %s failed: %v", ins.HealthPath, err))
+		healthEvent.SetAttrs(map[string]string{
+			"threshold_desc": fmt.Sprintf("%s: connection failed", ins.ConnectivitySeverity),
+		})
+		q.PushFront(healthEvent)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyReadSize))
+
+	if resp.StatusCode != http.StatusOK {
+		healthEvent.SetEventStatus(ins.ConnectivitySeverity)
+		healthEvent.SetDescription(fmt.Sprintf("GET %s returned HTTP %d: %s", ins.HealthPath, resp.StatusCode, truncate(string(body), 200)))
+		healthEvent.SetAttrs(map[string]string{
+			"threshold_desc": fmt.Sprintf("%s: non-200 status", ins.ConnectivitySeverity),
+			"current_value":  fmt.Sprintf("HTTP %d", resp.StatusCode),
+		})
+		q.PushFront(healthEvent)
+		return
+	}
+
+	var result struct {
+		Health string `json:"health"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil || result.Health != "true" {
+		healthEvent.SetEventStatus(ins.ConnectivitySeverity)
+		desc := fmt.Sprintf("etcd reports unhealthy: %s", truncate(string(body), 200))
+		if err != nil {
+			desc = fmt.Sprintf("failed to parse health response: %v, body: %s", err, truncate(string(body), 200))
+		}
+		healthEvent.SetDescription(desc)
+		healthEvent.SetAttrs(map[string]string{
+			"threshold_desc": fmt.Sprintf("%s: health != true", ins.ConnectivitySeverity),
+			"current_value":  result.Health,
+		})
+		q.PushFront(healthEvent)
+		return
+	}
+
+	healthEvent.SetDescription("etcd is healthy")
+	q.PushFront(healthEvent)
+}
+
+// ---------------------------------------------------------------------------
+// Metrics pre-fetch & quota auto-detection
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) needMetricsFetch() bool {
+	if !ins.DbSizePct.Disabled && ins.DbSizePct.QuotaBackendBytes == 0 {
+		return true
+	}
+	return len(activeQuantileChecks(ins.QuantileChecks)) > 0 ||
+		len(activeQuantileChecks(ins.WalFsyncChecks)) > 0 ||
+		ins.needDeltaCounters()
+}
+
+func (ins *Instance) fetchMetricsBody(target string) []byte {
+	url := target + ins.MetricsPath
+	resp, err := ins.client.Get(url)
+	if err != nil {
+		logger.Logger.Warnw("etcd: failed to fetch metrics", "target", target, "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		logger.Logger.Warnw("etcd: metrics returned non-200",
+			"target", target, "status", resp.StatusCode, "body", truncate(string(errBody), 200))
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxMetricsBytes)))
+	if err != nil {
+		logger.Logger.Warnw("etcd: failed to read metrics body", "target", target, "error", err)
+		return nil
+	}
+	return body
+}
+
+// resolveQuota determines the effective quota for db_size_pct checks.
+// Priority: user-configured value > cached auto-detect > fresh auto-detect > etcd default (2GB).
+func (ins *Instance) resolveQuota(target string, metricsBody []byte) int64 {
+	if ins.DbSizePct.QuotaBackendBytes > 0 {
+		return int64(ins.DbSizePct.QuotaBackendBytes)
+	}
+
+	if len(metricsBody) > 0 {
+		for _, line := range strings.Split(string(metricsBody), "\n") {
+			if strings.HasPrefix(line, "etcd_server_quota_backend_bytes") {
+				if v := parseMetricValue(line); v > 0 {
+					quota := int64(v)
+					if prev, ok := ins.cachedQuota[target]; !ok || prev != quota {
+						logger.Logger.Infow("etcd: auto-detected quota from metrics",
+							"target", target, "quota_bytes", quota, "quota_human", humanBytes(v))
+					}
+					ins.cachedQuota[target] = quota
+					return quota
+				}
+			}
+		}
+	}
+
+	if cached, ok := ins.cachedQuota[target]; ok && cached > 0 {
+		return cached
+	}
+
+	logger.Logger.Warnw("etcd: could not auto-detect quota, using etcd default 2GB",
+		"target", target)
+	ins.cachedQuota[target] = defaultQuotaBackendBytes
+	return defaultQuotaBackendBytes
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2+3: status → has_leader + db_size_pct
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) gatherStatus(q *safe.Queue[*types.Event], target string, metricsBody []byte) {
+	needLeader := !ins.HasLeader.Disabled
+	needDbSize := !ins.DbSizePct.Disabled
+	if !needLeader && !needDbSize {
+		return
+	}
+
+	body, err := ins.postJSON(target, "/v3/maintenance/status")
+	if err != nil {
+		if needLeader {
+			q.PushFront(ins.newEvent("etcd::has_leader", target).
+				SetEventStatus(ins.HasLeader.Severity).
+				SetDescription(fmt.Sprintf("failed to query maintenance status: %v", err)).
+				SetAttrs(map[string]string{
+					"threshold_desc": fmt.Sprintf("%s: status query failed", ins.HasLeader.Severity),
+				}))
+		}
+		if needDbSize {
+			q.PushFront(ins.newEvent("etcd::db_size_pct", target).
+				SetEventStatus(types.EventStatusWarning).
+				SetDescription(fmt.Sprintf("failed to query maintenance status: %v", err)).
+				SetAttrs(map[string]string{
+					"threshold_desc": "Warning: status query failed",
+				}))
+		}
+		return
+	}
+
+	// etcd gRPC gateway serializes protobuf int64 fields as JSON strings.
+	var status struct {
+		Leader   string `json:"leader"`
+		DbSize   string `json:"dbSize"`
+		RaftTerm string `json:"raftTerm"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil {
+		logger.Logger.Warnw("etcd: failed to parse status response", "target", target, "error", err)
+		return
+	}
+
+	if needLeader {
+		ins.checkHasLeader(q, target, status.Leader)
+	}
+	if needDbSize {
+		dbSize, _ := strconv.ParseFloat(status.DbSize, 64)
+		quota := ins.resolveQuota(target, metricsBody)
+		ins.checkDbSizePct(q, target, dbSize, quota)
+	}
+}
+
+func (ins *Instance) checkHasLeader(q *safe.Queue[*types.Event], target, leader string) {
+	event := ins.newEvent("etcd::has_leader", target)
+	event.SetAttrs(map[string]string{
+		"leader":         leader,
+		"threshold_desc": fmt.Sprintf("%s: cluster has no leader", ins.HasLeader.Severity),
+	}).SetCurrentValue(leader)
+
+	if leader == "" || leader == "0" {
+		event.SetEventStatus(ins.HasLeader.Severity)
+		event.SetDescription("etcd cluster has no leader — cluster is unavailable for writes")
+		q.PushFront(event)
+		return
+	}
+
+	event.SetDescription(fmt.Sprintf("etcd cluster has leader (ID: %s)", leader))
+	q.PushFront(event)
+}
+
+func (ins *Instance) checkDbSizePct(q *safe.Queue[*types.Event], target string, dbSize float64, quotaBytes int64) {
+	event := ins.newEvent("etcd::db_size_pct", target)
+
+	quota := float64(quotaBytes)
+	pct := dbSize / quota * 100
+
+	var parts []string
+	if ins.DbSizePct.WarnGe > 0 {
+		parts = append(parts, fmt.Sprintf("Warning >= %.0f%%", ins.DbSizePct.WarnGe))
+	}
+	if ins.DbSizePct.CriticalGe > 0 {
+		parts = append(parts, fmt.Sprintf("Critical >= %.0f%%", ins.DbSizePct.CriticalGe))
+	}
+
+	pctStr := fmt.Sprintf("%.1f%%", pct)
+	event.SetAttrs(map[string]string{
+		"current_value":     pctStr,
+		"db_size":           humanBytes(dbSize),
+		"quota":             humanBytes(quota),
+		"threshold_desc":    strings.Join(parts, ", "),
+	}).SetCurrentValue(pctStr)
+
+	status := types.EvaluateGeThreshold(pct, ins.DbSizePct.WarnGe, ins.DbSizePct.CriticalGe)
+	switch status {
+	case types.EventStatusCritical:
+		event.SetEventStatus(types.EventStatusCritical)
+		event.SetDescription(fmt.Sprintf("etcd db size %s (%.1f%% of quota %s) >= critical threshold %.0f%%",
+			humanBytes(dbSize), pct, humanBytes(quota), ins.DbSizePct.CriticalGe))
+	case types.EventStatusWarning:
+		event.SetEventStatus(types.EventStatusWarning)
+		event.SetDescription(fmt.Sprintf("etcd db size %s (%.1f%% of quota %s) >= warning threshold %.0f%%",
+			humanBytes(dbSize), pct, humanBytes(quota), ins.DbSizePct.WarnGe))
+	default:
+		event.SetDescription(fmt.Sprintf("etcd db size %s (%.1f%% of quota %s)",
+			humanBytes(dbSize), pct, humanBytes(quota)))
+	}
+	q.PushFront(event)
+}
+
+// ---------------------------------------------------------------------------
+// Layer 4: alarms (NOSPACE / CORRUPT)
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) gatherAlarms(q *safe.Queue[*types.Event], target string) {
+	if ins.Alarm.Disabled {
+		return
+	}
+
+	event := ins.newEvent("etcd::alarm", target)
+
+	payload := map[string]interface{}{"action": 0, "memberID": 0}
+	body, err := ins.postJSONPayload(target, "/v3/maintenance/alarm", payload)
+	if err != nil {
+		event.SetEventStatus(types.EventStatusWarning)
+		event.SetDescription(fmt.Sprintf("failed to query alarms: %v", err))
+		event.SetAttrs(map[string]string{
+			"threshold_desc": fmt.Sprintf("%s: alarm query failed", ins.Alarm.Severity),
+		})
+		q.PushFront(event)
+		return
+	}
+
+	var resp struct {
+		Alarms []struct {
+			Alarm    string `json:"alarm"`
+			MemberID string `json:"memberID"`
+		} `json:"alarms"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		event.SetEventStatus(types.EventStatusWarning)
+		event.SetDescription(fmt.Sprintf("failed to parse alarm response: %v", err))
+		q.PushFront(event)
+		return
+	}
+
+	event.SetAttrs(map[string]string{
+		"alarm_count":    strconv.Itoa(len(resp.Alarms)),
+		"threshold_desc": fmt.Sprintf("%s: active alarms detected", ins.Alarm.Severity),
+	})
+
+	if len(resp.Alarms) == 0 {
+		event.SetDescription("no active etcd alarms")
+		q.PushFront(event)
+		return
+	}
+
+	var alarmDescs []string
+	for _, a := range resp.Alarms {
+		alarmDescs = append(alarmDescs, fmt.Sprintf("%s(member:%s)", a.Alarm, a.MemberID))
+	}
+	event.SetEventStatus(ins.Alarm.Severity)
+	event.SetCurrentValue(strings.Join(alarmDescs, ", "))
+	event.SetDescription(fmt.Sprintf("etcd has %d active alarm(s): %s",
+		len(resp.Alarms), strings.Join(alarmDescs, ", ")))
+	q.PushFront(event)
+}
+
+// ---------------------------------------------------------------------------
+// Layer 5: metrics — histograms (backend_commit + wal_fsync) + delta counters
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) processMetrics(q *safe.Queue[*types.Event], target string, metricsBody []byte) {
+	commitChecks := activeQuantileChecks(ins.QuantileChecks)
+	walChecks := activeQuantileChecks(ins.WalFsyncChecks)
+	needDeltas := ins.needDeltaCounters()
+
+	if len(commitChecks) == 0 && len(walChecks) == 0 && !needDeltas {
+		return
+	}
+
+	if metricsBody == nil {
+		ins.emitMetricsFetchError(q, target, commitChecks, walChecks,
+			fmt.Sprintf("failed to fetch metrics from %s%s", target, ins.MetricsPath))
+		return
+	}
+
+	// Parse backend commit histogram
+	if len(commitChecks) > 0 {
+		h, parseErr := parseHistogram(bytes.NewReader(metricsBody), ins.HistogramMetric, maxMetricsBytes)
+		if parseErr != nil {
+			for _, qc := range commitChecks {
+				q.PushFront(ins.newEvent("etcd::backend_commit_"+quantileCheckLabel(qc.Phi), target).
+					SetEventStatus(types.EventStatusWarning).
+					SetDescription(fmt.Sprintf("failed to parse histogram %s: %v", ins.HistogramMetric, parseErr)).
+					SetAttrs(map[string]string{"threshold_desc": "Warning: metrics parse failed"}))
+			}
+		} else {
+			for _, qc := range commitChecks {
+				ins.emitQuantileEvent(q, target, "etcd::backend_commit_", qc, h, ins.HistogramMetric)
+			}
+		}
+	}
+
+	// Parse WAL fsync histogram
+	if len(walChecks) > 0 {
+		h, parseErr := parseHistogram(bytes.NewReader(metricsBody), ins.WalFsyncMetric, maxMetricsBytes)
+		if parseErr != nil {
+			for _, qc := range walChecks {
+				q.PushFront(ins.newEvent("etcd::wal_fsync_"+quantileCheckLabel(qc.Phi), target).
+					SetEventStatus(types.EventStatusWarning).
+					SetDescription(fmt.Sprintf("failed to parse histogram %s: %v", ins.WalFsyncMetric, parseErr)).
+					SetAttrs(map[string]string{"threshold_desc": "Warning: metrics parse failed"}))
+			}
+		} else {
+			for _, qc := range walChecks {
+				ins.emitQuantileEvent(q, target, "etcd::wal_fsync_", qc, h, ins.WalFsyncMetric)
+			}
+		}
+	}
+
+	// Parse delta counters
+	if needDeltas {
+		ins.gatherDeltaCounters(q, target, metricsBody)
+	}
+}
+
+func (ins *Instance) emitMetricsFetchError(q *safe.Queue[*types.Event], target string, commitChecks, walChecks []QuantileCheck, desc string) {
+	for _, qc := range commitChecks {
+		q.PushFront(ins.newEvent("etcd::backend_commit_"+quantileCheckLabel(qc.Phi), target).
+			SetEventStatus(ins.ConnectivitySeverity).
+			SetDescription(desc).
+			SetAttrs(map[string]string{"threshold_desc": fmt.Sprintf("%s: metrics fetch failed", ins.ConnectivitySeverity)}))
+	}
+	for _, qc := range walChecks {
+		q.PushFront(ins.newEvent("etcd::wal_fsync_"+quantileCheckLabel(qc.Phi), target).
+			SetEventStatus(ins.ConnectivitySeverity).
+			SetDescription(desc).
+			SetAttrs(map[string]string{"threshold_desc": fmt.Sprintf("%s: metrics fetch failed", ins.ConnectivitySeverity)}))
+	}
+}
+
+func (ins *Instance) emitQuantileEvent(q *safe.Queue[*types.Event], target, checkPrefix string, qc QuantileCheck, h *histogram, metricName string) {
+	checkLabel := checkPrefix + quantileCheckLabel(qc.Phi)
+	event := ins.newEvent(checkLabel, target)
+
+	val, err := histogramQuantile(qc.Phi, h)
+	if err != nil {
+		event.SetEventStatus(types.EventStatusWarning)
+		event.SetDescription(fmt.Sprintf("failed to compute quantile phi=%v: %v", qc.Phi, err))
+		q.PushFront(event)
+		return
+	}
+
+	latency := time.Duration(val * float64(time.Second))
+	latencyStr := formatLatency(latency)
+	warnStr := time.Duration(qc.WarnGe).String()
+	critStr := time.Duration(qc.CriticalGe).String()
+
+	var threshParts []string
+	if qc.WarnGe > 0 {
+		threshParts = append(threshParts, fmt.Sprintf("Warning >= %s", warnStr))
+	}
+	if qc.CriticalGe > 0 {
+		threshParts = append(threshParts, fmt.Sprintf("Critical >= %s", critStr))
+	}
+
+	event.SetAttrs(map[string]string{
+		"current_value":  latencyStr,
+		"threshold_desc": strings.Join(threshParts, ", "),
+		"phi":            fmt.Sprintf("%v", qc.Phi),
+		"metric":         metricName,
+	}).SetCurrentValue(latencyStr)
+
+	label := quantileCheckLabel(qc.Phi)
+	shortMetric := strings.TrimPrefix(checkPrefix, "etcd::")
+	shortMetric = strings.TrimSuffix(shortMetric, "_")
+
+	if qc.CriticalGe > 0 && latency >= time.Duration(qc.CriticalGe) {
+		event.SetEventStatus(types.EventStatusCritical)
+		event.SetDescription(fmt.Sprintf("%s %s latency %s >= critical threshold %s",
+			shortMetric, label, latencyStr, critStr))
+	} else if qc.WarnGe > 0 && latency >= time.Duration(qc.WarnGe) {
+		event.SetEventStatus(types.EventStatusWarning)
+		event.SetDescription(fmt.Sprintf("%s %s latency %s >= warning threshold %s",
+			shortMetric, label, latencyStr, warnStr))
+	} else {
+		event.SetDescription(fmt.Sprintf("%s %s latency %s, within threshold",
+			shortMetric, label, latencyStr))
+	}
+
+	q.PushFront(event)
+}
+
+// ---------------------------------------------------------------------------
+// Delta counters (slow_apply, leader_changes, proposals_failed)
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) needDeltaCounters() bool {
+	return (ins.SlowApply.WarnGe > 0 || ins.SlowApply.CriticalGe > 0) ||
+		(ins.LeaderChanges.WarnGe > 0 || ins.LeaderChanges.CriticalGe > 0) ||
+		(ins.ProposalsFailed.WarnGe > 0 || ins.ProposalsFailed.CriticalGe > 0)
+}
+
+func (ins *Instance) gatherDeltaCounters(q *safe.Queue[*types.Event], target string, metricsBody []byte) {
+	lines := strings.Split(string(metricsBody), "\n")
+	gauges := make(map[string]uint64)
+
+	wantMetrics := map[string]bool{
+		"etcd_server_slow_apply_total":         true,
+		"etcd_server_leader_changes_seen_total": true,
+		"etcd_server_proposals_failed_total":    true,
+	}
+
+	for _, line := range lines {
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		for name := range wantMetrics {
+			if strings.HasPrefix(line, name+" ") || strings.HasPrefix(line, name+"{") {
+				val := parseMetricValue(line)
+				if val >= 0 {
+					gauges[name] = uint64(val)
+				}
+				break
+			}
+		}
+	}
+
+	var snap etcdCounterSnapshot
+	if v, ok := gauges["etcd_server_slow_apply_total"]; ok {
+		snap.slowApply = v
+	}
+	if v, ok := gauges["etcd_server_leader_changes_seen_total"]; ok {
+		snap.leaderChanges = v
+	}
+	if v, ok := gauges["etcd_server_proposals_failed_total"]; ok {
+		snap.proposalsFailed = v
+	}
+
+	ins.statsMu.Lock()
+	prev := ins.prevStats[target]
+	wasInitialized := ins.initialized[target]
+	ins.prevStats[target] = snap
+	ins.initialized[target] = true
+	ins.statsMu.Unlock()
+
+	if !wasInitialized {
+		if ins.SlowApply.WarnGe > 0 || ins.SlowApply.CriticalGe > 0 {
+			q.PushFront(ins.newEvent("etcd::slow_apply", target).SetAttrs(map[string]string{
+				"delta": "0", "total": strconv.FormatUint(snap.slowApply, 10),
+			}).SetDescription(fmt.Sprintf("etcd slow apply baseline established (total: %d)", snap.slowApply)))
+		}
+		if ins.LeaderChanges.WarnGe > 0 || ins.LeaderChanges.CriticalGe > 0 {
+			q.PushFront(ins.newEvent("etcd::leader_changes", target).SetAttrs(map[string]string{
+				"delta": "0", "total": strconv.FormatUint(snap.leaderChanges, 10),
+			}).SetDescription(fmt.Sprintf("etcd leader changes baseline established (total: %d)", snap.leaderChanges)))
+		}
+		if ins.ProposalsFailed.WarnGe > 0 || ins.ProposalsFailed.CriticalGe > 0 {
+			q.PushFront(ins.newEvent("etcd::proposals_failed", target).SetAttrs(map[string]string{
+				"delta": "0", "total": strconv.FormatUint(snap.proposalsFailed, 10),
+			}).SetDescription(fmt.Sprintf("etcd proposals failed baseline established (total: %d)", snap.proposalsFailed)))
+		}
+		return
+	}
+
+	if ins.SlowApply.WarnGe > 0 || ins.SlowApply.CriticalGe > 0 {
+		delta := safeDelta(snap.slowApply, prev.slowApply)
+		ins.checkDeltaCounter(q, target, "etcd::slow_apply", delta, snap.slowApply, ins.SlowApply, "slow apply")
+	}
+	if ins.LeaderChanges.WarnGe > 0 || ins.LeaderChanges.CriticalGe > 0 {
+		delta := safeDelta(snap.leaderChanges, prev.leaderChanges)
+		ins.checkDeltaCounter(q, target, "etcd::leader_changes", delta, snap.leaderChanges, ins.LeaderChanges, "leader changes")
+	}
+	if ins.ProposalsFailed.WarnGe > 0 || ins.ProposalsFailed.CriticalGe > 0 {
+		delta := safeDelta(snap.proposalsFailed, prev.proposalsFailed)
+		ins.checkDeltaCounter(q, target, "etcd::proposals_failed", delta, snap.proposalsFailed, ins.ProposalsFailed, "proposals failed")
+	}
+}
+
+func (ins *Instance) checkDeltaCounter(q *safe.Queue[*types.Event], target, check string, delta, total uint64, thresholds DeltaCounterCheck, metricName string) {
+	var parts []string
+	if thresholds.WarnGe > 0 {
+		parts = append(parts, fmt.Sprintf("Warning >= %d", thresholds.WarnGe))
+	}
+	if thresholds.CriticalGe > 0 {
+		parts = append(parts, fmt.Sprintf("Critical >= %d", thresholds.CriticalGe))
+	}
+	attrs := map[string]string{
+		"delta":          strconv.FormatUint(delta, 10),
+		"total":          strconv.FormatUint(total, 10),
+		"threshold_desc": strings.Join(parts, ", "),
+	}
+	event := ins.newEvent(check, target).SetAttrs(attrs).SetCurrentValue(strconv.FormatUint(delta, 10))
+
+	status := types.EvaluateGeThreshold(float64(delta), float64(thresholds.WarnGe), float64(thresholds.CriticalGe))
+	switch status {
+	case types.EventStatusCritical:
+		event.SetEventStatus(types.EventStatusCritical)
+		event.SetDescription(fmt.Sprintf("etcd %s delta %d >= critical threshold %d", metricName, delta, thresholds.CriticalGe))
+	case types.EventStatusWarning:
+		event.SetEventStatus(types.EventStatusWarning)
+		event.SetDescription(fmt.Sprintf("etcd %s delta %d >= warning threshold %d", metricName, delta, thresholds.WarnGe))
+	default:
+		event.SetDescription(fmt.Sprintf("etcd %s delta %d, within threshold", metricName, delta))
+	}
+	q.PushFront(event)
+}
+
+func safeDelta(cur, prev uint64) uint64 {
+	if cur >= prev {
+		return cur - prev
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers for gRPC gateway POST calls
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) postJSON(target, path string) ([]byte, error) {
+	return ins.postJSONPayload(target, path, nil)
+}
+
+func (ins *Instance) postJSONPayload(target, path string, payload any) ([]byte, error) {
+	var bodyReader io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	} else {
+		bodyReader = bytes.NewReader([]byte("{}"))
+	}
+
+	req, err := http.NewRequest(http.MethodPost, target+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ins.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyReadSize))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	return body, nil
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+func (ins *Instance) newEvent(check, target string) *types.Event {
+	return types.BuildEvent(map[string]string{
+		"check":  check,
+		"target": target,
+	})
+}
+
+func activeQuantileChecks(checks []QuantileCheck) []QuantileCheck {
+	var active []QuantileCheck
+	for _, qc := range checks {
+		if !qc.Disabled {
+			active = append(active, qc)
+		}
+	}
+	return active
+}
+
+func formatLatency(d time.Duration) string {
+	if d < time.Millisecond {
+		return fmt.Sprintf("%.1fus", float64(d)/float64(time.Microsecond))
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.1fms", float64(d)/float64(time.Millisecond))
+	}
+	return fmt.Sprintf("%.3fs", d.Seconds())
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
+}
+

--- a/plugins/etcd/etcd_test.go
+++ b/plugins/etcd/etcd_test.go
@@ -1,0 +1,487 @@
+package etcd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cprobe/catpaw/digcore/config"
+	"github.com/cprobe/catpaw/digcore/logger"
+	"github.com/cprobe/catpaw/digcore/pkg/safe"
+	"github.com/cprobe/catpaw/digcore/types"
+	"go.uber.org/zap"
+)
+
+func TestMain(m *testing.M) {
+	l, _ := zap.NewDevelopment()
+	logger.Logger = l.Sugar()
+	os.Exit(m.Run())
+}
+
+// ---------------------------------------------------------------------------
+// Init defaults & validation
+// ---------------------------------------------------------------------------
+
+func TestInitDefaults(t *testing.T) {
+	ins := &Instance{Targets: []string{"http://127.0.0.1:2379"}}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if ins.HasLeader.Severity != types.EventStatusCritical {
+		t.Errorf("has_leader severity = %q, want Critical", ins.HasLeader.Severity)
+	}
+	if ins.Alarm.Severity != types.EventStatusCritical {
+		t.Errorf("alarm severity = %q, want Critical", ins.Alarm.Severity)
+	}
+	if ins.DbSizePct.QuotaBackendBytes != 0 {
+		t.Errorf("quota = %d, want 0 (auto-detect)", ins.DbSizePct.QuotaBackendBytes)
+	}
+	if ins.DbSizePct.WarnGe != 80 {
+		t.Errorf("db_size_pct.warn_ge = %v, want 80", ins.DbSizePct.WarnGe)
+	}
+	if ins.DbSizePct.CriticalGe != 90 {
+		t.Errorf("db_size_pct.critical_ge = %v, want 90", ins.DbSizePct.CriticalGe)
+	}
+	if ins.WalFsyncMetric != "etcd_disk_wal_fsync_duration_seconds" {
+		t.Errorf("wal_fsync_metric = %q", ins.WalFsyncMetric)
+	}
+}
+
+func TestInitCustomQuota(t *testing.T) {
+	ins := &Instance{
+		Targets:   []string{"http://127.0.0.1:2379"},
+		DbSizePct: DbSizePctCheck{QuotaBackendBytes: 8 * config.GB},
+	}
+	if err := ins.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if ins.DbSizePct.QuotaBackendBytes != 8*config.GB {
+		t.Errorf("quota = %d, want 8GB", ins.DbSizePct.QuotaBackendBytes)
+	}
+}
+
+func TestInitValidation(t *testing.T) {
+	ins := &Instance{
+		Targets:   []string{"http://127.0.0.1:2379"},
+		DbSizePct: DbSizePctCheck{WarnGe: 95, CriticalGe: 80},
+	}
+	err := ins.Init()
+	if err == nil {
+		t.Fatal("expected validation error for warn_ge >= critical_ge")
+	}
+	if !strings.Contains(err.Error(), "db_size_pct") {
+		t.Errorf("error should mention db_size_pct: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// has_leader check
+// ---------------------------------------------------------------------------
+
+func popEvent(q *safe.Queue[*types.Event]) *types.Event {
+	ptr := q.PopBack()
+	if ptr == nil {
+		return nil
+	}
+	return *ptr
+}
+
+func TestCheckHasLeader_OK(t *testing.T) {
+	ins := &Instance{HasLeader: HasLeaderCheck{Severity: types.EventStatusCritical}}
+	q := safe.NewQueue[*types.Event]()
+	ins.checkHasLeader(q, "http://test:2379", "12345")
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusOk {
+		t.Errorf("status = %s, want Ok", event.EventStatus)
+	}
+	if !strings.Contains(event.Description, "has leader") {
+		t.Errorf("desc = %q, should mention has leader", event.Description)
+	}
+}
+
+func TestCheckHasLeader_NoLeader(t *testing.T) {
+	ins := &Instance{HasLeader: HasLeaderCheck{Severity: types.EventStatusCritical}}
+	q := safe.NewQueue[*types.Event]()
+	ins.checkHasLeader(q, "http://test:2379", "0")
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusCritical {
+		t.Errorf("status = %s, want Critical", event.EventStatus)
+	}
+}
+
+func TestCheckHasLeader_Empty(t *testing.T) {
+	ins := &Instance{HasLeader: HasLeaderCheck{Severity: types.EventStatusCritical}}
+	q := safe.NewQueue[*types.Event]()
+	ins.checkHasLeader(q, "http://test:2379", "")
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusCritical {
+		t.Errorf("status = %s, want Critical", event.EventStatus)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// db_size_pct check
+// ---------------------------------------------------------------------------
+
+func TestCheckDbSizePct_OK(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{
+		WarnGe:     80,
+		CriticalGe: 90,
+	}}
+	q := safe.NewQueue[*types.Event]()
+	ins.checkDbSizePct(q, "http://test:2379", 1*1024*1024*1024, 2*1024*1024*1024) // 50%
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusOk {
+		t.Errorf("status = %s, want Ok", event.EventStatus)
+	}
+}
+
+func TestCheckDbSizePct_Warning(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{
+		WarnGe:     80,
+		CriticalGe: 90,
+	}}
+	q := safe.NewQueue[*types.Event]()
+	ins.checkDbSizePct(q, "http://test:2379", 1.7*1024*1024*1024, 2*1024*1024*1024) // ~85%
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusWarning {
+		t.Errorf("status = %s, want Warning", event.EventStatus)
+	}
+}
+
+func TestCheckDbSizePct_Critical(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{
+		WarnGe:     80,
+		CriticalGe: 90,
+	}}
+	q := safe.NewQueue[*types.Event]()
+	ins.checkDbSizePct(q, "http://test:2379", 1.9*1024*1024*1024, 2*1024*1024*1024) // ~95%
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusCritical {
+		t.Errorf("status = %s, want Critical", event.EventStatus)
+	}
+}
+
+func TestResolveQuota_Configured(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{QuotaBackendBytes: 8 * config.GB}, cachedQuota: make(map[string]int64)}
+	got := ins.resolveQuota("http://test:2379", nil)
+	if got != int64(8*config.GB) {
+		t.Errorf("resolveQuota = %d, want 8GB", got)
+	}
+}
+
+func TestResolveQuota_AutoDetect(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{}, cachedQuota: make(map[string]int64)}
+	metrics := []byte("etcd_server_quota_backend_bytes 8.589934592e+09\n")
+	got := ins.resolveQuota("http://test:2379", metrics)
+	if got != 8589934592 {
+		t.Errorf("resolveQuota = %d, want 8589934592", got)
+	}
+}
+
+func TestResolveQuota_AutoDetect_CacheNoRepeatLog(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{}, cachedQuota: make(map[string]int64)}
+	metrics := []byte("etcd_server_quota_backend_bytes 8.589934592e+09\n")
+	ins.resolveQuota("http://test:2379", metrics)
+	if ins.cachedQuota["http://test:2379"] != 8589934592 {
+		t.Errorf("cachedQuota not set after first call")
+	}
+	got := ins.resolveQuota("http://test:2379", metrics)
+	if got != 8589934592 {
+		t.Errorf("resolveQuota = %d on second call, want 8589934592", got)
+	}
+}
+
+func TestResolveQuota_FallbackDefault(t *testing.T) {
+	ins := &Instance{DbSizePct: DbSizePctCheck{}, cachedQuota: make(map[string]int64)}
+	got := ins.resolveQuota("http://test:2379", nil)
+	if got != defaultQuotaBackendBytes {
+		t.Errorf("resolveQuota = %d, want %d (default)", got, defaultQuotaBackendBytes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// alarm check (with HTTP mock)
+// ---------------------------------------------------------------------------
+
+func TestGatherAlarms_NoAlarms(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"alarms": []interface{}{}})
+	}))
+	defer server.Close()
+
+	ins := &Instance{
+		Targets: []string{server.URL},
+		Alarm:   AlarmCheck{Severity: types.EventStatusCritical},
+		client:  server.Client(),
+	}
+	q := safe.NewQueue[*types.Event]()
+	ins.gatherAlarms(q, server.URL)
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusOk {
+		t.Errorf("status = %s, want Ok", event.EventStatus)
+	}
+}
+
+func TestGatherAlarms_HasAlarm(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"alarms": []map[string]string{
+				{"alarm": "NOSPACE", "memberID": "12345"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ins := &Instance{
+		Targets: []string{server.URL},
+		Alarm:   AlarmCheck{Severity: types.EventStatusCritical},
+		client:  server.Client(),
+	}
+	q := safe.NewQueue[*types.Event]()
+	ins.gatherAlarms(q, server.URL)
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusCritical {
+		t.Errorf("status = %s, want Critical", event.EventStatus)
+	}
+	if !strings.Contains(event.Description, "NOSPACE") {
+		t.Errorf("desc should mention NOSPACE: %q", event.Description)
+	}
+}
+
+func TestGatherAlarms_Disabled(t *testing.T) {
+	ins := &Instance{
+		Targets: []string{"http://test:2379"},
+		Alarm:   AlarmCheck{Disabled: true},
+	}
+	q := safe.NewQueue[*types.Event]()
+	ins.gatherAlarms(q, "http://test:2379")
+	if q.Len() != 0 {
+		t.Errorf("expected no events when alarm check is disabled, got %d", q.Len())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta counters
+// ---------------------------------------------------------------------------
+
+func TestDeltaCounters_Baseline(t *testing.T) {
+	metrics := `etcd_server_slow_apply_total 10
+etcd_server_leader_changes_seen_total 2
+etcd_server_proposals_failed_total 0
+`
+	ins := &Instance{
+		Targets:     []string{"http://test:2379"},
+		SlowApply:   DeltaCounterCheck{WarnGe: 1},
+		prevStats:   make(map[string]etcdCounterSnapshot),
+		initialized: make(map[string]bool),
+	}
+	q := safe.NewQueue[*types.Event]()
+	ins.gatherDeltaCounters(q, "http://test:2379", []byte(metrics))
+
+	event := popEvent(q)
+	if !strings.Contains(event.Description, "baseline") {
+		t.Errorf("first gather should establish baseline: %q", event.Description)
+	}
+}
+
+func TestDeltaCounters_Delta(t *testing.T) {
+	ins := &Instance{
+		Targets:   []string{"http://test:2379"},
+		SlowApply: DeltaCounterCheck{WarnGe: 1, CriticalGe: 5},
+		prevStats: map[string]etcdCounterSnapshot{
+			"http://test:2379": {slowApply: 10},
+		},
+		initialized: map[string]bool{"http://test:2379": true},
+	}
+
+	metrics := `etcd_server_slow_apply_total 13
+`
+	q := safe.NewQueue[*types.Event]()
+	ins.gatherDeltaCounters(q, "http://test:2379", []byte(metrics))
+
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusWarning {
+		t.Errorf("status = %s, want Warning (delta=3)", event.EventStatus)
+	}
+	if !strings.Contains(event.Description, "delta 3") {
+		t.Errorf("desc should mention delta 3: %q", event.Description)
+	}
+}
+
+func TestDeltaCounters_Critical(t *testing.T) {
+	ins := &Instance{
+		Targets:   []string{"http://test:2379"},
+		SlowApply: DeltaCounterCheck{WarnGe: 1, CriticalGe: 5},
+		prevStats: map[string]etcdCounterSnapshot{
+			"http://test:2379": {slowApply: 10},
+		},
+		initialized: map[string]bool{"http://test:2379": true},
+	}
+
+	metrics := `etcd_server_slow_apply_total 20
+`
+	q := safe.NewQueue[*types.Event]()
+	ins.gatherDeltaCounters(q, "http://test:2379", []byte(metrics))
+
+	event := popEvent(q)
+	if event.EventStatus != types.EventStatusCritical {
+		t.Errorf("status = %s, want Critical (delta=10)", event.EventStatus)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full gather with HTTP mock
+// ---------------------------------------------------------------------------
+
+func TestGatherFullHTTP(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"health":"true"}`)
+	})
+
+	mux.HandleFunc("/v3/maintenance/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// etcd gRPC gateway returns int64 fields as JSON strings
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"leader":      "12345",
+			"dbSize":      fmt.Sprintf("%d", 500*1024*1024),
+			"dbSizeInUse": fmt.Sprintf("%d", 400*1024*1024),
+			"header":      map[string]interface{}{"member_id": "12345"},
+		})
+	})
+
+	mux.HandleFunc("/v3/maintenance/alarm", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"alarms": []interface{}{}})
+	})
+
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `# HELP etcd_server_quota_backend_bytes Current backend storage quota size in bytes.
+# TYPE etcd_server_quota_backend_bytes gauge
+etcd_server_quota_backend_bytes 2.147483648e+09
+# TYPE etcd_disk_backend_commit_duration_seconds histogram
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.001"} 0
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.002"} 100
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.004"} 500
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.008"} 900
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"} 990
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.032"} 1000
+etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf"} 1000
+etcd_disk_backend_commit_duration_seconds_sum 3.5
+etcd_disk_backend_commit_duration_seconds_count 1000
+`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ins := &Instance{
+		Targets:     []string{server.URL},
+		Concurrency: 1,
+		QuantileChecks: []QuantileCheck{
+			{Phi: 0.99, WarnGe: config.Duration(100 * time.Millisecond), CriticalGe: config.Duration(250 * time.Millisecond)},
+		},
+		HasLeader: HasLeaderCheck{Severity: types.EventStatusCritical},
+		DbSizePct: DbSizePctCheck{
+			WarnGe:     80,
+			CriticalGe: 90,
+		},
+		Alarm:       AlarmCheck{Severity: types.EventStatusCritical},
+		client:      server.Client(),
+		prevStats:   make(map[string]etcdCounterSnapshot),
+		initialized: make(map[string]bool),
+		cachedQuota: make(map[string]int64),
+	}
+	ins.HealthPath = "/health"
+	ins.MetricsPath = "/metrics"
+	ins.HistogramMetric = "etcd_disk_backend_commit_duration_seconds"
+	ins.WalFsyncMetric = "etcd_disk_wal_fsync_duration_seconds"
+	ins.ConnectivitySeverity = types.EventStatusCritical
+
+	q := safe.NewQueue[*types.Event]()
+	ins.gather(q, server.URL)
+
+	events := make(map[string]*types.Event)
+	for q.Len() > 0 {
+		e := popEvent(q)
+		events[e.Labels["check"]] = e
+	}
+
+	// health OK
+	if e, ok := events["etcd::health"]; !ok {
+		t.Error("missing etcd::health event")
+	} else if e.EventStatus != types.EventStatusOk {
+		t.Errorf("health status = %s, want Ok", e.EventStatus)
+	}
+
+	// has_leader OK
+	if e, ok := events["etcd::has_leader"]; !ok {
+		t.Error("missing etcd::has_leader event")
+	} else if e.EventStatus != types.EventStatusOk {
+		t.Errorf("has_leader status = %s, want Ok", e.EventStatus)
+	}
+
+	// db_size_pct OK (~24%)
+	if e, ok := events["etcd::db_size_pct"]; !ok {
+		t.Error("missing etcd::db_size_pct event")
+	} else if e.EventStatus != types.EventStatusOk {
+		t.Errorf("db_size_pct status = %s, want Ok", e.EventStatus)
+	}
+
+	// alarm OK
+	if e, ok := events["etcd::alarm"]; !ok {
+		t.Error("missing etcd::alarm event")
+	} else if e.EventStatus != types.EventStatusOk {
+		t.Errorf("alarm status = %s, want Ok", e.EventStatus)
+	}
+
+	// backend commit quantile OK (p99 should be ~16ms range, well under 100ms)
+	if e, ok := events["etcd::backend_commit_p99"]; !ok {
+		t.Error("missing etcd::backend_commit_p99 event")
+	} else if e.EventStatus != types.EventStatusOk {
+		t.Errorf("backend_commit_p99 status = %s, want Ok", e.EventStatus)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation tests
+// ---------------------------------------------------------------------------
+
+func TestValidateDeltaCounterCheck(t *testing.T) {
+	if err := validateDeltaCounterCheck("test", DeltaCounterCheck{WarnGe: 5, CriticalGe: 3}); err == nil {
+		t.Error("expected error for warn_ge >= critical_ge")
+	}
+	if err := validateDeltaCounterCheck("test", DeltaCounterCheck{WarnGe: 3, CriticalGe: 5}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateQuantileChecks(t *testing.T) {
+	if err := validateQuantileChecks("test", []QuantileCheck{{Phi: 1.5}}); err == nil {
+		t.Error("expected error for phi > 1")
+	}
+	if err := validateQuantileChecks("test", []QuantileCheck{
+		{Phi: 0.99, WarnGe: config.Duration(500 * time.Millisecond), CriticalGe: config.Duration(100 * time.Millisecond)},
+	}); err == nil {
+		t.Error("expected error for warn_ge >= critical_ge")
+	}
+}
+
+func TestSafeDelta(t *testing.T) {
+	if safeDelta(10, 5) != 5 {
+		t.Error("normal delta failed")
+	}
+	if safeDelta(5, 10) != 0 {
+		t.Error("counter reset should return 0")
+	}
+}

--- a/plugins/etcd/histogram.go
+++ b/plugins/etcd/histogram.go
@@ -1,0 +1,207 @@
+package etcd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// histogram holds parsed Prometheus histogram data for a single metric+label set.
+type histogram struct {
+	Buckets []bucket // sorted by upper bound ascending
+	Sum     float64
+	Count   float64
+}
+
+type bucket struct {
+	UpperBound float64
+	Count      float64 // cumulative
+}
+
+// histogramQuantile computes the φ-quantile from cumulative histogram buckets,
+// using the same linear interpolation algorithm as Prometheus.
+// It expects buckets sorted by UpperBound with a +Inf bucket present.
+func histogramQuantile(phi float64, h *histogram) (float64, error) {
+	if len(h.Buckets) == 0 {
+		return 0, fmt.Errorf("no buckets")
+	}
+	if phi < 0 || phi > 1 {
+		return 0, fmt.Errorf("phi must be in [0,1], got %v", phi)
+	}
+
+	buckets := ensureMonotonic(h.Buckets)
+
+	if len(buckets) == 0 || buckets[len(buckets)-1].Count == 0 {
+		return math.NaN(), nil
+	}
+
+	total := buckets[len(buckets)-1].Count
+	rank := phi * total
+
+	// Find the bucket where rank falls into.
+	for i, b := range buckets {
+		if b.Count >= rank {
+			var (
+				lower      float64
+				lowerCount float64
+			)
+			if i > 0 {
+				lower = buckets[i-1].UpperBound
+				lowerCount = buckets[i-1].Count
+			}
+			if math.IsInf(b.UpperBound, 1) {
+				// Last bucket is +Inf; approximate with previous bucket upper bound.
+				if i > 0 {
+					return lower, nil
+				}
+				return math.NaN(), nil
+			}
+			// Linear interpolation within the bucket.
+			bucketCount := b.Count - lowerCount
+			if bucketCount == 0 {
+				return lower, nil
+			}
+			return lower + (b.UpperBound-lower)*(rank-lowerCount)/bucketCount, nil
+		}
+	}
+
+	return math.NaN(), nil
+}
+
+// ensureMonotonic applies monotonicity correction to cumulative bucket counts.
+// Prometheus does this to handle counter resets within scrape intervals.
+func ensureMonotonic(raw []bucket) []bucket {
+	if len(raw) == 0 {
+		return raw
+	}
+	out := make([]bucket, len(raw))
+	copy(out, raw)
+	max := out[len(out)-1].Count
+	for i := len(out) - 2; i >= 0; i-- {
+		if out[i].Count > max {
+			out[i].Count = max
+		}
+		max = out[i].Count
+	}
+	return out
+}
+
+// parseHistogram scans Prometheus text exposition and extracts the histogram
+// for the given metric name. It collects _bucket, _sum, and _count lines.
+// The reader is limited to maxBytes to prevent unbounded memory usage.
+func parseHistogram(r io.Reader, metricName string, maxBytes int64) (*histogram, error) {
+	lr := io.LimitReader(r, maxBytes)
+	scanner := bufio.NewScanner(lr)
+
+	bucketPrefix := metricName + "_bucket{"
+	sumPrefix := metricName + "_sum"
+	countPrefix := metricName + "_count"
+
+	h := &histogram{}
+	var foundBucket bool
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, bucketPrefix):
+			le, count, err := parseBucketLine(line, bucketPrefix)
+			if err != nil {
+				continue
+			}
+			h.Buckets = append(h.Buckets, bucket{UpperBound: le, Count: count})
+			foundBucket = true
+
+		case strings.HasPrefix(line, sumPrefix):
+			h.Sum = parseMetricValue(line)
+
+		case strings.HasPrefix(line, countPrefix):
+			h.Count = parseMetricValue(line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan metrics: %w", err)
+	}
+
+	if !foundBucket {
+		return nil, fmt.Errorf("metric %q not found or has no buckets", metricName)
+	}
+
+	sort.Slice(h.Buckets, func(i, j int) bool {
+		return h.Buckets[i].UpperBound < h.Buckets[j].UpperBound
+	})
+
+	return h, nil
+}
+
+// parseBucketLine extracts (le, count) from a line like:
+//
+//	metric_bucket{le="0.01"} 42
+func parseBucketLine(line, prefix string) (float64, float64, error) {
+	rest := line[len(prefix):]
+	leIdx := strings.Index(rest, "le=\"")
+	if leIdx < 0 {
+		return 0, 0, fmt.Errorf("no le label")
+	}
+	rest = rest[leIdx+4:]
+	endQuote := strings.Index(rest, "\"")
+	if endQuote < 0 {
+		return 0, 0, fmt.Errorf("no closing quote for le")
+	}
+	leStr := rest[:endQuote]
+
+	var le float64
+	if leStr == "+Inf" {
+		le = math.Inf(1)
+	} else {
+		var err error
+		le, err = strconv.ParseFloat(leStr, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	// Value is after the closing "}" and whitespace.
+	closeBrace := strings.Index(line, "}")
+	if closeBrace < 0 {
+		return 0, 0, fmt.Errorf("no closing brace")
+	}
+	valStr := strings.TrimSpace(line[closeBrace+1:])
+	count, err := strconv.ParseFloat(valStr, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return le, count, nil
+}
+
+// parseMetricValue extracts the numeric value from "metric_name{...} VALUE" or "metric_name VALUE".
+func parseMetricValue(line string) float64 {
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return 0
+	}
+	v, _ := strconv.ParseFloat(parts[len(parts)-1], 64)
+	return v
+}
+
+// quantileCheckLabel returns the check label suffix for a given phi.
+// 0.90 → "p90", 0.95 → "p95", 0.999 → "p999".
+func quantileCheckLabel(phi float64) string {
+	scaled := phi * 100
+	rounded := math.Round(scaled*10) / 10
+	if rounded == math.Trunc(rounded) {
+		return fmt.Sprintf("p%d", int(rounded))
+	}
+	s := strconv.FormatFloat(rounded, 'f', -1, 64)
+	s = strings.ReplaceAll(s, ".", "")
+	return "p" + s
+}

--- a/plugins/etcd/histogram_test.go
+++ b/plugins/etcd/histogram_test.go
@@ -1,0 +1,142 @@
+package etcd
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestHistogramQuantile(t *testing.T) {
+	h := &histogram{
+		Buckets: []bucket{
+			{UpperBound: 0.001, Count: 0},
+			{UpperBound: 0.002, Count: 0},
+			{UpperBound: 0.004, Count: 0},
+			{UpperBound: 0.008, Count: 0},
+			{UpperBound: 0.016, Count: 4},
+			{UpperBound: 0.032, Count: 5},
+			{UpperBound: 0.064, Count: 6},
+			{UpperBound: 0.128, Count: 7},
+			{UpperBound: 0.256, Count: 8},
+			{UpperBound: 0.512, Count: 9},
+			{UpperBound: 1.024, Count: 10},
+			{UpperBound: math.Inf(1), Count: 10},
+		},
+		Sum:   0.250,
+		Count: 10,
+	}
+
+	tests := []struct {
+		phi  float64
+		want float64
+	}{
+		{0.5, 0.032},
+		{0.9, 0.512},
+		{0.99, 0.9728},
+	}
+
+	for _, tc := range tests {
+		got, err := histogramQuantile(tc.phi, h)
+		if err != nil {
+			t.Fatalf("phi=%v: %v", tc.phi, err)
+		}
+		if math.Abs(got-tc.want) > 0.001 {
+			t.Errorf("phi=%v: got=%v, want=%v", tc.phi, got, tc.want)
+		}
+	}
+}
+
+func TestHistogramQuantile_EmptyBuckets(t *testing.T) {
+	h := &histogram{}
+	_, err := histogramQuantile(0.5, h)
+	if err == nil {
+		t.Error("expected error for empty buckets")
+	}
+}
+
+func TestHistogramQuantile_ZeroCount(t *testing.T) {
+	h := &histogram{
+		Buckets: []bucket{
+			{UpperBound: 0.01, Count: 0},
+			{UpperBound: math.Inf(1), Count: 0},
+		},
+	}
+	got, err := histogramQuantile(0.5, h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsNaN(got) {
+		t.Errorf("expected NaN for zero count, got %v", got)
+	}
+}
+
+func TestParseHistogram(t *testing.T) {
+	const metrics = `# HELP etcd_disk_backend_commit_duration_seconds The latency distributions of commit called by backend.
+# TYPE etcd_disk_backend_commit_duration_seconds histogram
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.001"} 0
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.002"} 0
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.004"} 0
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.008"} 0
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"} 150
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.032"} 500
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.064"} 800
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.128"} 950
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.256"} 990
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.512"} 999
+etcd_disk_backend_commit_duration_seconds_bucket{le="1.024"} 1000
+etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf"} 1000
+etcd_disk_backend_commit_duration_seconds_sum 23.456
+etcd_disk_backend_commit_duration_seconds_count 1000
+# some other metric
+etcd_server_proposals_applied_total 12345
+`
+
+	h, err := parseHistogram(strings.NewReader(metrics), "etcd_disk_backend_commit_duration_seconds", 8<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(h.Buckets) != 12 {
+		t.Fatalf("expected 12 buckets, got %d", len(h.Buckets))
+	}
+	if h.Sum != 23.456 {
+		t.Errorf("sum: got %v, want 23.456", h.Sum)
+	}
+	if h.Count != 1000 {
+		t.Errorf("count: got %v, want 1000", h.Count)
+	}
+
+	p99, err := histogramQuantile(0.99, h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p99 < 0.1 || p99 > 1.0 {
+		t.Errorf("p99=%v out of expected range [0.1, 1.0]", p99)
+	}
+}
+
+func TestParseHistogram_NotFound(t *testing.T) {
+	_, err := parseHistogram(strings.NewReader("some_other_metric 42\n"), "etcd_disk_backend_commit_duration_seconds", 8<<20)
+	if err == nil {
+		t.Error("expected error for missing metric")
+	}
+}
+
+func TestQuantileCheckLabel(t *testing.T) {
+	tests := []struct {
+		phi  float64
+		want string
+	}{
+		{0.50, "p50"},
+		{0.90, "p90"},
+		{0.95, "p95"},
+		{0.99, "p99"},
+		{0.999, "p999"},
+	}
+	for _, tc := range tests {
+		got := quantileCheckLabel(tc.phi)
+		if got != tc.want {
+			t.Errorf("quantileCheckLabel(%v): got %q, want %q", tc.phi, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add etcd monitoring plugin with health, alarms, db_size_pct, and Prometheus histogram checks (backend_commit, wal_fsync, slow_apply, leader_changes, proposals_failed)
- Auto-detect quota from `etcd_server_quota_backend_bytes` metric with caching
- AI diagnose tools: `etcd_status`, `etcd_alarms`, `etcd_metrics_relevant`
- Improve diagnose report forwarding with debug logging in engine and flashduty notifier

## Test plan

- [x] All 24 etcd plugin unit tests pass
- [x] Histogram tests pass
- [x] Diagnose module tests pass
- [x] `go vet` clean, `go build` clean
- [x] Rebased on latest master, no conflicts